### PR TITLE
Add stable User Library identity, audit, and lifecycle management

### DIFF
--- a/.wisp-plugin/plugin.json
+++ b/.wisp-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schema": "wisp.plugin.v1",
   "id": "figure-library",
   "display_name": "Scientific Figure Library",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Search FigureYa and user-supplied figures/code as reusable scientific plotting references.",
   "author": "xuzhougeng and contributors",
   "license": "MIT (code); CC BY-NC-SA 4.0 (FigureYa assets)",

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ and approving the exact canonical/duplicate IDs, hashes, and reason. Apply:
 Rollback uses the same `reconcileId` and refuses to overwrite any later
 manifest change. Never manually delete a lock, transaction directory, template
 directory, or migration ledger until the interrupted state has been inspected.
+If a dead process leaves `prepared`, `committing`, or `rolling-back`, first
+verify that its recorded lock owner is no longer running and inspect the
+journal. After the stale lock is deliberately cleared, rollback with the exact
+same reconcile ID/canonical/duplicate IDs. Recovery accepts only manifests that
+still equal that journal's before/after hashes and removes only a matching
+partial apply ledger.
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ importing, and materializing scientific figure references. It is not tied to
 Wisp: any stdio MCP host can use it. The included Wisp manifest and Skill are a
 thin optional adapter.
 
-The first release has two template sources:
+The library has two template sources:
 
 - **FigureYa** — 319 searchable modules with local thumbnails and
   commit-pinned archives.
@@ -68,19 +68,28 @@ npm run check
 - `figure_library_open` — open an empty candidate workbench.
 - `figure_library_search` — search FigureYa and/or the user library.
 - `figure_library_import` — safely copy a user figure and/or code into the
-  library, or validate and import a Figure Transfer Package.
+  library, or validate and import a Figure Transfer Package. Direct-write mode
+  remains for v0.2 compatibility; new Agents should use plan/apply.
+- `figure_library_plan_import` — validate a direct import, calculate stable
+  identity and component-level duplicate evidence, and write nothing.
+- `figure_library_apply_import` — revalidate and apply one exact confirmed
+  direct-import plan.
 - `figure_library_diff` — validate one Transfer Package or Gallery entry and
   return a read-only create/update/unchanged diff.
 - `figure_library_upsert` — explicitly apply a stable Transfer Package or
   Gallery create/update.
 - `figure_library_sync` — validate or synchronize a Personal Gallery; dry-run
   is the default.
-- `figure_library_archive` — logically archive a Gallery entry without deleting
-  its snapshot.
+- `figure_library_archive` — logically archive any User Library entry by
+  `templateId`, legacy `galleryId`, or adapter-scoped Registry source.
 - `figure_library_preview` — return a candidate as MCP image content and,
   optionally, a checked project-local preview path for Agent inspection.
-- `figure_library_source_status` — inspect the user library and a FigureYa
-  Source Pack.
+- `figure_library_source_status` — inspect effective User Library/Gallery paths,
+  lifecycle counts, integrity counts, and a FigureYa Source Pack.
+- `figure_library_audit` — read and verify manifests/files, legacy entries, and
+  component-level duplicate evidence without writing.
+- `figure_library_reconcile` — dry-run, apply, or roll back an explicitly
+  approved logical duplicate archive using a write lock and recovery journal.
 - `figure_library_describe` — inspect one exact template.
 - `figure_library_materialize` — write one selected reference to a project.
 
@@ -97,7 +106,9 @@ absolute project-local `destination` (for example,
 path. This keeps visual judgment with the Agent even when the host exposes only
 the text portion of an MCP tool result.
 
-Example import arguments:
+## Stable direct imports
+
+For new direct imports, plan first:
 
 ```json
 {
@@ -106,11 +117,42 @@ Example import arguments:
   "tags": ["volcano", "differential expression"],
   "visualProfile": "log2FC x-axis, -log10 FDR y-axis, labeled hits",
   "dataProfile": "gene, log2FC, adjusted p value",
+  "sourceKey": "manual:lab-volcano-v1",
   "imagePath": "/project/references/volcano.png",
   "codePaths": ["/project/references/volcano.R"],
   "license": "Internal lab reference"
 }
 ```
+
+`sourceKey` is optional, but recommended for an entry that should be updated in
+place. It is a portable logical key: 1–200 lowercase ASCII letters, digits,
+dot, underscore, colon, or hyphen. Never use a host path, URL with query data,
+token, email, patient identifier, or other secret. Personal Gallery entries
+must use `gallery_id` and Gallery sync rather than a direct `sourceKey`.
+
+The plan returns `action`, confirmed title, proposed/existing `templateId`,
+component fingerprints, matching templates, and `planDigest`, with
+`written: false`. Present these fields, review status, and license to the user.
+Only then call `figure_library_apply_import` with the same import fields plus:
+
+```json
+{
+  "planDigest": "<64-hex plan digest>",
+  "expectedAction": "create",
+  "expectedTemplateId": "user-direct-<16-hex>",
+  "operationId": "lab-volcano-create-1"
+}
+```
+
+The apply step re-reads files and the User Library. A stale plan is rejected.
+An exact create replay is safe. A `duplicate_candidate` requires an explicit
+`reuse` or `create_separate` decision and reason; a `source_conflict` requires
+an explicit `replace_source` reason. Template IDs never contain the raw
+`sourceKey` and do not change when an existing stable source's title changes.
+
+Without `sourceKey`, identity is content-addressed from the complete asset
+fingerprint. Metadata can be revised for the same asset, but changing preview
+or code intentionally produces a new-source candidate.
 
 Supported visual references are PNG, JPEG, WebP, SVG, and PDF (20 MiB maximum).
 Up to 20 R, R Markdown, Quarto, Python, notebook, Julia, MATLAB, Markdown,
@@ -256,6 +298,54 @@ filter can be used for review/audit. Search and sync also accept `assetKind`,
 `language`, `plotFamily`, and `codeStatus` filters, keeping visual-only
 references separate from reusable R templates.
 
+## Identity, management, audit, and reconcile
+
+Every new Registry entry records an adapter-scoped logical source and versioned
+component fingerprints for preview, executable code, data, metadata, and the
+full asset. Component overlap is duplicate evidence only: equal previews or
+similar titles never trigger an automatic merge.
+
+`registry.contentHash` remains the v0.2-compatible normalized **source snapshot
+hash**. It is not the byte hash of the current `template.json`: local lifecycle
+operations such as archive change review state without redefining the imported
+source. Audit therefore calculates separate `manifestSha256` and
+`verifiedFileSetDigest` values from the current manifest and verified files.
+
+Search and describe return a `management` object. Use its `templateId` as the
+normal archive reference. `registrySourceId` is deliberately distinct from the
+top-level search source (`figureya` or `user`). Gallery authority remains in
+`figure.yml`; if a Gallery snapshot is locally archived while its Gallery entry
+is still approved, the next sync will plan to restore the authoritative state.
+
+Audit before any legacy cleanup:
+
+```json
+{
+  "scope": "all",
+  "includeArchived": true
+}
+```
+
+Audit reports unreadable/invalid entries instead of silently omitting them,
+verifies every declared file, marks Registry-less legacy direct templates, and
+returns a duplicate evidence graph plus a deterministic **recommendation only**
+for the canonical ID.
+
+`figure_library_reconcile` defaults to `mode: "dry-run"`. Its `expectedState`
+must copy the exact `manifestSha256`, `verifiedFileSetDigest`, and review status
+from the reviewed audit. Apply only after backing up the complete User Library
+and approving the exact canonical/duplicate IDs, hashes, and reason. Apply:
+
+- acquires the same User Library write lock as import/upsert/sync/archive;
+- archives only the named duplicate manifests;
+- retains every directory and reference file;
+- records a recovery journal and append-only alias ledger;
+- refuses stale state and incomplete prior transactions.
+
+Rollback uses the same `reconcileId` and refuses to overwrite any later
+manifest change. Never manually delete a lock, transaction directory, template
+directory, or migration ledger until the interrupted state has been inspected.
+
 ## Distribution
 
 The standalone npm tarball contains the server, App, FigureYa search catalog,
@@ -263,7 +353,7 @@ and thumbnails, but not the large archive collection:
 
 ```bash
 npm run package:npm
-npm install --global ./release/scientific-figure-library-0.2.0.tgz
+npm install --global ./release/scientific-figure-library-0.3.0.tgz
 ```
 
 Use `scientific-figure-library` as the MCP command after installation.
@@ -274,7 +364,7 @@ For Wisp:
 npm run package:wisp
 ```
 
-Install `release/scientific-figure-library-wisp-0.2.0.zip` from Wisp
+Install `release/scientific-figure-library-wisp-0.3.0.zip` from Wisp
 **Settings → Plugins**, enable it for a project, and start a fresh session.
 
 ## FigureYa Source Pack
@@ -310,7 +400,7 @@ npm run package:source-pack -- \
 
 The helper verifies every selected ZIP and caps one transport pack at 200 MiB.
 Extract the resulting
-`release/figure-library-source-pack-volcano-0.2.0.zip` before use.
+`release/figure-library-source-pack-volcano-0.3.0.zip` before use.
 
 ## Materialized layouts
 

--- a/app/main.ts
+++ b/app/main.ts
@@ -27,6 +27,16 @@ interface Candidate {
   reviewStatus: "draft" | "approved" | "archived";
   codeStatus: "none" | "scaffold" | "reviewed";
   previewDataUrl?: string;
+  management: {
+    templateId: string;
+    adapter?: "direct" | "gallery" | "figure-transfer-package";
+    registrySourceId?: string;
+    galleryId?: string;
+    identityMode?: "stable-source" | "content-addressed";
+    canArchive: boolean;
+    canUpdate: boolean;
+    updateVia?: "plan-apply" | "diff-upsert" | "gallery-sync";
+  };
 }
 
 interface SearchResult {
@@ -42,7 +52,7 @@ const cards = document.getElementById("cards")!;
 const empty = document.getElementById("empty")!;
 const query = document.getElementById("query")!;
 const status = document.getElementById("status")!;
-const app = new App({ name: "Scientific Figure Library", version: "0.2.0" });
+const app = new App({ name: "Scientific Figure Library", version: "0.3.0" });
 
 function element<K extends keyof HTMLElementTagNameMap>(
   tag: K,
@@ -73,9 +83,13 @@ async function selectCandidate(candidate: Candidate, button: HTMLButtonElement) 
 source: Scientific Figure Library MCP App
 selectedTemplate: ${candidate.templateId}
 templateSource: ${candidate.sourceId}
+templateTitle: ${candidate.title}
+templateAdapter: ${candidate.management.adapter ?? "none"}
+templateRegistrySource: ${candidate.management.registrySourceId ?? "none"}
+templateGalleryId: ${candidate.management.galleryId ?? "none"}
 ---
 
-The user asked the Agent to review **${candidate.templateId}** from **${candidate.sourceLabel}**.
+The user asked the Agent to review **${candidate.title}** (\`${candidate.templateId}\`) from **${candidate.sourceLabel}**.
 Classification: ${candidate.assetKind}; language ${candidate.language}; review ${candidate.reviewStatus}; code ${candidate.codeStatus}.
 Retrieval score is ${candidate.retrievalScore}/100; it is not a final recommendation or confidence.
 Reasons: ${candidate.reasons.join("; ") || "catalog metadata match"}.
@@ -114,7 +128,8 @@ function render(result: SearchResult) {
     const top = element("div", "topline");
     const heading = element("div");
     heading.append(
-      element("h2", "module", candidate.templateId),
+      element("h2", "module", candidate.title),
+      element("code", "template-id", candidate.templateId),
       element("span", `source source-${candidate.sourceId}`, candidate.sourceLabel),
     );
     top.append(
@@ -130,9 +145,14 @@ function render(result: SearchResult) {
       candidate.plotFamily,
       candidate.reviewStatus,
       candidate.codeStatus,
+      candidate.management.adapter,
+      candidate.management.galleryId ? `gallery:${candidate.management.galleryId}` : "",
+      candidate.management.registrySourceId
+        ? `source:${candidate.management.registrySourceId}`
+        : "",
       ...candidate.inputFiles.slice(0, 3),
       ...candidate.packages.slice(0, 3).map((name) => `pkg:${name}`),
-    ].filter(Boolean);
+    ].filter((value): value is string => Boolean(value));
     if (tags.length) content.append(chips(tags));
     if (candidate.reasons[0]) content.append(element("p", "reason", candidate.reasons[0]));
     if (candidate.warnings[0]) content.append(element("p", "warning", candidate.warnings[0]));

--- a/app/styles.css
+++ b/app/styles.css
@@ -119,6 +119,15 @@ footer {
   line-height: 1.25;
 }
 
+.template-id {
+  display: block;
+  margin-top: 0.3rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+  user-select: all;
+}
+
 .source {
   display: inline-block;
   margin-top: 5px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scientific-figure-library",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scientific-figure-library",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scientific-figure-library",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A portable MCP server and MCP App for searching, importing, and materializing scientific figure templates.",
   "type": "module",
   "bin": {
@@ -19,7 +19,7 @@
     "build": "tsc --noEmit && vite build && esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/index.js --banner:js='#!/usr/bin/env node\nimport { createRequire as __nodeCreateRequire } from \"node:module\"; const require = __nodeCreateRequire(import.meta.url);'",
     "catalog": "node scripts/build-catalog.mjs",
     "package:source-pack": "node scripts/package-source-pack.mjs",
-    "package:npm": "npm run build && npm pack --pack-destination release",
+    "package:npm": "npm run build && node -e \"require('node:fs').mkdirSync('release',{recursive:true})\" && npm pack --pack-destination release",
     "package:wisp": "npm run build && node scripts/package-wisp.mjs",
     "start": "node dist/index.js",
     "test": "node --test tests/*.test.ts",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -18,6 +18,8 @@ const sourceDirectory = path.join(smokeRoot, "source");
 await fs.mkdir(sourceDirectory);
 const codePath = path.join(sourceDirectory, "smoke-plot.R");
 await fs.writeFile(codePath, "# unique-smoke-ridge-reference\n");
+const plannedCodePath = path.join(sourceDirectory, "planned-smoke-plot.R");
+await fs.writeFile(plannedCodePath, "# planned-smoke-lifecycle-reference\n");
 const transferImage = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
 const transferPackagePath = path.join(sourceDirectory, "figure-transfer-package.zip");
 const transferManifest = {
@@ -63,7 +65,7 @@ const childEnvironment = Object.fromEntries(
 );
 childEnvironment.FIGURE_LIBRARY_DIR = libraryDirectory;
 
-const client = new Client({ name: "scientific-figure-library-smoke", version: "0.2.0" });
+const client = new Client({ name: "scientific-figure-library-smoke", version: "0.3.0" });
 const transport = new StdioClientTransport({
   command: process.execPath,
   args: [serverEntry],
@@ -80,12 +82,16 @@ try {
     "figure_library_open",
     "figure_library_search",
     "figure_library_import",
+    "figure_library_plan_import",
+    "figure_library_apply_import",
     "figure_library_diff",
     "figure_library_upsert",
     "figure_library_sync",
     "figure_library_archive",
     "figure_library_preview",
     "figure_library_source_status",
+    "figure_library_audit",
+    "figure_library_reconcile",
     "figure_library_describe",
     "figure_library_materialize",
   ]) {
@@ -154,6 +160,47 @@ try {
   const userTemplateId = imported.structuredContent?.templateId;
   if (imported.isError || typeof userTemplateId !== "string") {
     throw new Error(`user import smoke call failed: ${JSON.stringify(imported.content)}`);
+  }
+
+  const planned = await client.callTool({
+    name: "figure_library_plan_import",
+    arguments: {
+      title: "Planned smoke lifecycle reference",
+      description: "A direct import that exercises plan, apply, management, archive, and audit.",
+      sourceKey: "smoke:planned-lifecycle",
+      codePaths: [plannedCodePath],
+    },
+  });
+  const plannedTemplateId = planned.structuredContent?.proposedTemplateId;
+  const planDigest = planned.structuredContent?.planDigest;
+  if (
+    planned.isError ||
+    planned.structuredContent?.action !== "create" ||
+    planned.structuredContent?.written !== false ||
+    typeof plannedTemplateId !== "string" ||
+    typeof planDigest !== "string"
+  ) {
+    throw new Error(`direct import plan smoke call failed: ${JSON.stringify(planned.content)}`);
+  }
+  const plannedApplied = await client.callTool({
+    name: "figure_library_apply_import",
+    arguments: {
+      title: "Planned smoke lifecycle reference",
+      description: "A direct import that exercises plan, apply, management, archive, and audit.",
+      sourceKey: "smoke:planned-lifecycle",
+      codePaths: [plannedCodePath],
+      planDigest,
+      expectedAction: "create",
+      expectedTemplateId: plannedTemplateId,
+      operationId: "smoke-planned-create",
+    },
+  });
+  if (
+    plannedApplied.isError ||
+    plannedApplied.structuredContent?.templateId !== plannedTemplateId ||
+    plannedApplied.structuredContent?.action !== "create"
+  ) {
+    throw new Error(`direct import apply smoke call failed: ${JSON.stringify(plannedApplied.content)}`);
   }
 
   const transferImported = await client.callTool({
@@ -245,8 +292,33 @@ try {
     name: "figure_library_source_status",
     arguments: {},
   });
-  if (sourceStatus.isError || sourceStatus.structuredContent?.userTemplateCount !== 2) {
+  if (sourceStatus.isError || sourceStatus.structuredContent?.userTemplateCount !== 3) {
     throw new Error("source status smoke call failed");
+  }
+
+  const plannedArchive = await client.callTool({
+    name: "figure_library_archive",
+    arguments: { templateId: plannedTemplateId },
+  });
+  if (
+    plannedArchive.isError ||
+    plannedArchive.structuredContent?.changed !== true ||
+    plannedArchive.structuredContent?.filesRetained !== true
+  ) {
+    throw new Error(`template archive smoke call failed: ${JSON.stringify(plannedArchive.content)}`);
+  }
+  const audit = await client.callTool({
+    name: "figure_library_audit",
+    arguments: { scope: "all", includeArchived: true },
+  });
+  if (
+    audit.isError ||
+    audit.structuredContent?.userTemplateCount !== 3 ||
+    !audit.structuredContent?.templates?.some(
+      (item) => item.templateId === plannedTemplateId && item.reviewStatus === "archived",
+    )
+  ) {
+    throw new Error(`user-library audit smoke call failed: ${JSON.stringify(audit.content)}`);
   }
 
   const resource = await client.readResource({
@@ -295,7 +367,7 @@ try {
   }
 
   console.log(
-    `OK: ${names.join(", ")}; Agent review preview; import/diff/upsert/sync/archive tools; user search/materialization; app resource; hard stop${materialized}`,
+    `OK: ${names.join(", ")}; Agent review preview; legacy import plus plan/apply/archive/audit lifecycle; diff/upsert/sync; user search/materialization; app resource; hard stop${materialized}`,
   );
 } finally {
   await client.close().catch(() => undefined);

--- a/skills/figure-library/SKILL.md
+++ b/skills/figure-library/SKILL.md
@@ -63,7 +63,10 @@ figure reference.
      same reconcile ID, IDs, manifest hashes, file-set digests, and reason →
      apply. Never delete a lock, transaction, template directory, or ledger.
      Roll back only through the recorded reconcile ID and only if post-state
-     hashes still match.
+     hashes still match. For an interrupted journal, first verify that the lock
+     owner is dead and inspect the journal; only then deliberately clear that
+     stale lock and use rollback with the exact recorded IDs. Do not hand-edit
+     template manifests or migration ledgers.
 4. Inspect the user's plotting request before searching:
    - For an image, **first call the host's `view_image` tool**. Describe the
      chart family, panels, axes, encodings, labels, and notable visual style

--- a/skills/figure-library/SKILL.md
+++ b/skills/figure-library/SKILL.md
@@ -13,8 +13,25 @@ figure reference.
    query.
 2. When the user wants to add their own reference:
    - Inspect the attached figure and/or code first.
-   - Call `figure_library_import` with host-local file paths and compact
-     metadata. Import at least one figure/reference or code file.
+   - For a direct image/code import, call `figure_library_plan_import` with
+     host-local file paths and compact metadata. Import at least one
+     figure/reference or code file. Use a portable, non-secret `sourceKey` when
+     the logical entry should support later updates; never use an absolute path,
+     URL query, token, email, or patient identifier.
+   - Present the normalized title, action, review status, license, proposed or
+     existing template ID, identity mode, and every duplicate/source match to
+     the user. The plan writes nothing. Do not treat a `planDigest` as user
+     authorization.
+   - Call `figure_library_apply_import` only after the user approves that exact
+     plan. Send the same fields and files plus the returned `planDigest`, exact
+     expected action/template ID, and a stable operation ID. If the plan is
+     stale, plan again and ask again; do not silently adapt the confirmation.
+   - A duplicate candidate requires an explicit `reuse` or `create_separate`
+     decision and reason. A source conflict requires explicit `replace_source`
+     approval and reason. Never change a title or source key merely to bypass a
+     conflict.
+   - `figure_library_import` direct-write mode exists only for v0.2 client
+     compatibility. Do not use it for a new Agent-managed direct import.
    - For a CiteBox or other Figure Transfer Package, pass only `packagePath`.
      A valid package is imported as a Draft visual reference; preserve its
      caption, DOI, page, URL, source IDs, and rights. Do not describe it as an
@@ -33,6 +50,20 @@ figure reference.
    - Use `figure_library_archive` for removal from normal search. It is a
      logical archive; do not hard-delete the Gallery source or User Library
      snapshot.
+   - Prefer the `management.templateId` returned by search/describe. For a
+     Gallery entry, change authoritative `figure.yml` status before sync;
+     otherwise a later sync can restore the approved snapshot.
+   - Before consolidating legacy or duplicate templates, call
+     `figure_library_audit`. Present invalid/integrity findings, the complete
+     component-evidence graph, and the recommended canonical ID as a
+     recommendation only. Equal preview or similar title is never automatic
+     merge permission.
+   - Reconcile requires: verified full-library backup → audit → exact human
+     canonical choice → `figure_library_reconcile` dry-run → approval of the
+     same reconcile ID, IDs, manifest hashes, file-set digests, and reason →
+     apply. Never delete a lock, transaction, template directory, or ledger.
+     Roll back only through the recorded reconcile ID and only if post-state
+     hashes still match.
 4. Inspect the user's plotting request before searching:
    - For an image, **first call the host's `view_image` tool**. Describe the
      chart family, panels, axes, encodings, labels, and notable visual style

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -601,6 +601,11 @@ export class CatalogIndex {
           license: "CC BY-NC-SA 4.0",
           sourceUrl: module.sourceUrl,
           reportUrl: module.reportUrl,
+          management: {
+            templateId: module.moduleId,
+            canArchive: false,
+            canUpdate: false,
+          },
         };
       });
   }

--- a/src/importers.ts
+++ b/src/importers.ts
@@ -5,6 +5,7 @@ import { unzipSync } from "fflate";
 import { parseDocument } from "yaml";
 import { z } from "zod";
 import type {
+  AssetFingerprintsV1,
   AssetKind,
   CodeStatus,
   ImportRegistryEntry,
@@ -34,7 +35,7 @@ export const IMAGE_TYPES = new Map([
 ]);
 export const EMBEDDABLE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
 
-const CODE_EXTENSIONS = new Set([
+export const CODE_EXTENSIONS = new Set([
   ".r",
   ".rmd",
   ".qmd",
@@ -66,6 +67,7 @@ interface PreparedFile<T extends StoredFile = StoredFile> {
 
 export interface PreparedTemplate {
   templateId: string;
+  legacyTemplateId?: string;
   title: string;
   description: string;
   tags: string[];
@@ -165,6 +167,68 @@ function canonicalize(value: unknown): unknown {
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([key, item]) => [key, canonicalize(item)]),
   );
+}
+
+function descriptorSetHash(
+  items: Array<{ role: string; file: string; bytes: number; sha256: string }>,
+) {
+  if (items.length === 0) return undefined;
+  const normalized = items
+    .map((item) => ({
+      role: item.role,
+      file: item.file.replaceAll("\\", "/"),
+      bytes: item.bytes,
+      sha256: item.sha256.toLocaleLowerCase(),
+    }))
+    .sort(
+      (left, right) =>
+        left.role.localeCompare(right.role) || left.file.localeCompare(right.file),
+    );
+  return sha256(JSON.stringify(normalized));
+}
+
+export function assetFingerprints(
+  preview: StoredPreview | undefined,
+  code: StoredFile[],
+  references: StoredReference[],
+): AssetFingerprintsV1 {
+  const executable = code
+    .filter((file) => CODE_EXTENSIONS.has(path.extname(file.file).toLocaleLowerCase()))
+    .map((file) => ({ role: "executable-code", ...file }));
+  const metadata = [
+    ...code
+      .filter((file) => !CODE_EXTENSIONS.has(path.extname(file.file).toLocaleLowerCase()))
+      .map((file) => ({ ...file, role: "metadata" })),
+    ...references
+      .filter((file) => file.role === "metadata")
+      .map((file) => ({ ...file, role: "metadata" })),
+  ];
+  const data = references
+    .filter((file) => file.role === "data")
+    .map((file) => ({ ...file, role: "data" }));
+  const previewItems = preview ? [{ role: "preview", ...preview }] : [];
+  return {
+    algorithm: "figure-library.asset-fingerprints.v1",
+    previewSha256: preview?.sha256.toLocaleLowerCase(),
+    executableCodeSetSha256: descriptorSetHash(executable),
+    dataSetSha256: descriptorSetHash(data),
+    metadataSetSha256: descriptorSetHash(metadata),
+    fullAssetSha256:
+      descriptorSetHash([...previewItems, ...executable, ...data, ...metadata]) ?? sha256("[]"),
+  };
+}
+
+export function normalizeDirectSourceKey(value: string) {
+  const normalized = value.normalize("NFKC").trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._:-]{0,199}$/u.test(normalized)) {
+    throw new Error(
+      "sourceKey must be 1-200 lowercase ASCII characters using letters, digits, dot, underscore, colon, or hyphen",
+    );
+  }
+  if (normalized.includes("://") || normalized.includes("..")) {
+    throw new Error("sourceKey must be a portable logical identifier, not a URL or path");
+  }
+  return normalized;
 }
 
 function contentHash(
@@ -320,10 +384,26 @@ export async function prepareDirectImport(input: UserTemplateImport): Promise<Pr
     JSON.stringify(advancedIdentity ? { ...legacyMetadata, ...metadata } : legacyMetadata),
   ).slice(0, 10);
   const hash = contentHash(metadata, preview, code, []);
+  const fingerprints = assetFingerprints(
+    preview?.stored,
+    code.map((item) => item.stored),
+    [],
+  );
+  const explicitSource = input.sourceKey ? normalizeDirectSourceKey(input.sourceKey) : undefined;
+  const sourceId = explicitSource ?? `direct:sha256:${fingerprints.fullAssetSha256}`;
+  const registry: ImportRegistryEntry = {
+    adapter: "direct",
+    sourceId,
+    contentHash: hash,
+    identityMode: explicitSource ? "stable-source" : "content-addressed",
+    fingerprints,
+  };
   validateTotalBytes(preview, code, []);
   return {
-    templateId: `user-${slug(metadata.title)}-${identity}`,
+    templateId: `user-direct-${sha256(`direct:${sourceId}`).slice(0, 16)}`,
+    legacyTemplateId: `user-${slug(metadata.title)}-${identity}`,
     ...metadata,
+    registry,
     contentHash: hash,
     preview,
     code,
@@ -551,11 +631,18 @@ export async function prepareTransferPackage(packagePath: string): Promise<Prepa
     },
   ];
   const hash = contentHash(metadata, preview, [], references);
+  const fingerprints = assetFingerprints(
+    preview.stored,
+    [],
+    references.map((item) => item.stored),
+  );
   const sourceId = `${manifest.producer.name}:${sourceIdValue}:${figureIdValue}`;
   const registry: ImportRegistryEntry = {
     adapter: "figure-transfer-package",
     sourceId,
     contentHash: hash,
+    identityMode: "stable-source",
+    fingerprints,
   };
   validateTotalBytes(preview, [], references);
   return {
@@ -851,6 +938,12 @@ export async function prepareGalleryEntry(
     galleryId: manifest.gallery_id,
     contentHash: hash,
     sourceCommit: manifest.source_commit ?? sourceCommit,
+    identityMode: "stable-source",
+    fingerprints: assetFingerprints(
+      preview?.stored,
+      code.map((item) => item.stored),
+      references.map((item) => item.stored),
+    ),
   };
   validateTotalBytes(preview, code, references);
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.ts";
 
-const VERSION = "0.2.0";
+const VERSION = "0.3.0";
 
 if (process.argv.includes("--help")) {
   console.log(`Scientific Figure Library ${VERSION}

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,11 +15,32 @@ import {
   materializeFigureYaTemplate,
 } from "./materialize.ts";
 import type { TemplateCandidate } from "./types.ts";
-import { UserTemplateLibrary } from "./user-library.ts";
+import { managementReference, UserTemplateLibrary } from "./user-library.ts";
 
-const VERSION = "0.2.0";
+const VERSION = "0.3.0";
 const RESOURCE_URI = "ui://figure-library/candidates.html";
 const APP_HTML = path.resolve(import.meta.dirname, "mcp-app.html");
+
+const ImportAdapterSchema = z.enum(["direct", "gallery", "figure-transfer-package"]);
+const IdentityModeSchema = z.enum(["stable-source", "content-addressed"]);
+const FingerprintsSchema = z.object({
+  algorithm: z.literal("figure-library.asset-fingerprints.v1"),
+  previewSha256: z.string().optional(),
+  executableCodeSetSha256: z.string().optional(),
+  dataSetSha256: z.string().optional(),
+  metadataSetSha256: z.string().optional(),
+  fullAssetSha256: z.string(),
+});
+const ManagementSchema = z.object({
+  templateId: z.string(),
+  adapter: ImportAdapterSchema.optional(),
+  registrySourceId: z.string().optional(),
+  galleryId: z.string().optional(),
+  identityMode: IdentityModeSchema.optional(),
+  canArchive: z.boolean(),
+  canUpdate: z.boolean(),
+  updateVia: z.enum(["plan-apply", "diff-upsert", "gallery-sync"]).optional(),
+});
 
 const CandidateSchema = z.object({
   templateId: z.string(),
@@ -48,6 +69,7 @@ const CandidateSchema = z.object({
   sourceUrl: z.string().optional(),
   reportUrl: z.string().optional(),
   previewDataUrl: z.string().optional(),
+  management: ManagementSchema,
 });
 
 const SearchInput = z.object({
@@ -132,6 +154,12 @@ const ImportInput = z
       .max(20)
       .optional()
       .describe("Host-local paths to code/reference files. Files are copied but never executed."),
+    sourceKey: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Portable stable source key for updateable direct imports. Never use a host path or secret."),
   })
   .superRefine((value, context) => {
     const direct = Boolean(value.imagePath || value.codePaths?.length);
@@ -159,6 +187,28 @@ const ImportOutput = z.object({
   warning: z.string(),
 });
 
+const DirectImportInput = z
+  .object({
+    title: z.string().min(1).max(200),
+    description: z.string().max(4_000).optional(),
+    tags: z.array(z.string().min(1).max(100)).max(40).optional(),
+    visualProfile: z.string().max(2_000).optional(),
+    dataProfile: z.string().max(2_000).optional(),
+    packages: z.array(z.string().min(1).max(100)).max(40).optional(),
+    license: z.string().max(500).optional(),
+    assetKind: z.enum(["plot_template", "visual_reference"]).optional(),
+    language: z.string().min(1).max(100).optional(),
+    plotFamily: z.string().max(200).optional(),
+    reviewStatus: z.enum(["draft", "approved", "archived"]).optional(),
+    codeStatus: z.enum(["none", "scaffold", "reviewed"]).optional(),
+    imagePath: z.string().min(1).max(2_000).optional(),
+    codePaths: z.array(z.string().min(1).max(2_000)).max(20).optional(),
+    sourceKey: z.string().min(1).max(200).optional(),
+  })
+  .refine((value) => Boolean(value.imagePath || value.codePaths?.length), {
+    message: "provide imagePath or at least one codePaths entry",
+  });
+
 const ImportSourceInput = z
   .object({
     packagePath: z.string().min(1).max(2_000).optional(),
@@ -175,9 +225,71 @@ const ImportChangeSchema = z.object({
   after: z.unknown(),
 });
 
+const DirectImportActionSchema = z.enum([
+  "create",
+  "unchanged",
+  "update",
+  "duplicate_candidate",
+  "source_conflict",
+]);
+const DirectImportMatchSchema = z.object({
+  templateId: z.string(),
+  title: z.string(),
+  matchKinds: z.array(z.string()),
+  manifestSha256: z.string(),
+});
+const DirectImportPlanOutput = z.object({
+  action: DirectImportActionSchema,
+  normalizedTitle: z.string(),
+  proposedTemplateId: z.string(),
+  registrySourceId: z.string(),
+  identityMode: IdentityModeSchema,
+  fingerprints: FingerprintsSchema,
+  contentHash: z.string(),
+  changes: z.array(ImportChangeSchema),
+  matches: z.array(DirectImportMatchSchema),
+  planDigest: z.string(),
+  written: z.literal(false),
+});
+const DirectImportApplyInput = z.object({
+  ...DirectImportInput.shape,
+  planDigest: z.string().regex(/^[a-f0-9]{64}$/u),
+  expectedAction: DirectImportActionSchema,
+  expectedTemplateId: z.string().min(1).max(200),
+  operationId: z.string().min(1).max(100).regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/u),
+  duplicateResolution: z
+    .union([
+      z.object({
+        action: z.literal("reuse"),
+        templateId: z.string().min(1).max(200),
+        reason: z.string().min(1).max(1_000),
+      }),
+      z.object({
+        action: z.literal("create_separate"),
+        reason: z.string().min(1).max(1_000),
+      }),
+    ])
+    .optional(),
+  sourceConflictResolution: z
+    .object({
+      action: z.literal("replace_source"),
+      reason: z.string().min(1).max(1_000),
+    })
+    .optional(),
+});
+const DirectImportApplyOutput = z.object({
+  templateId: z.string(),
+  title: z.string(),
+  directory: z.string(),
+  action: z.enum(["create", "unchanged", "update", "reused"]),
+  replayed: z.boolean(),
+  plan: DirectImportPlanOutput,
+  warning: z.string(),
+});
+
 const ImportDiffSchema = z.object({
   action: z.enum(["create", "unchanged", "update", "skipped"]),
-  adapter: z.enum(["gallery", "figure-transfer-package"]),
+  adapter: ImportAdapterSchema,
   sourceId: z.string(),
   galleryId: z.string().optional(),
   templateId: z.string(),
@@ -228,12 +340,37 @@ const GallerySyncOutput = z.object({
   results: z.array(ImportDiffSchema),
 });
 
-const ArchiveInput = z.object({ galleryId: z.string().min(1).max(300) });
+const ArchiveInput = z
+  .object({
+    templateId: z.string().min(1).max(200).optional(),
+    galleryId: z.string().min(1).max(300).optional(),
+    registrySourceId: z.string().min(1).max(300).optional(),
+    adapter: ImportAdapterSchema.optional(),
+  })
+  .superRefine((value, context) => {
+    const references = [value.templateId, value.galleryId, value.registrySourceId].filter(Boolean);
+    if (references.length !== 1) {
+      context.addIssue({
+        code: "custom",
+        message: "provide exactly one of templateId, galleryId, or registrySourceId + adapter",
+      });
+    }
+    if (value.registrySourceId && !value.adapter) {
+      context.addIssue({ code: "custom", message: "adapter is required with registrySourceId" });
+    }
+  });
 const ArchiveOutput = z.object({
-  galleryId: z.string(),
   templateId: z.string(),
+  galleryId: z.string().optional(),
+  registrySourceId: z.string().optional(),
+  adapter: ImportAdapterSchema.optional(),
+  previousReviewStatus: z.enum(["draft", "approved", "archived"]),
   reviewStatus: z.literal("archived"),
   directory: z.string(),
+  changed: z.boolean(),
+  alreadyArchived: z.boolean(),
+  filesRetained: z.literal(true),
+  // v0.2.0 compatibility: existed meant "already archived".
   existed: z.boolean(),
   warning: z.string(),
 });
@@ -260,12 +397,14 @@ const ProvenanceSchema = z.object({
 });
 
 const RegistrySchema = z.object({
-  adapter: z.enum(["gallery", "figure-transfer-package"]),
+  adapter: ImportAdapterSchema,
   sourceId: z.string(),
   templateId: z.string().optional(),
   galleryId: z.string().optional(),
   contentHash: z.string(),
   sourceCommit: z.string().optional(),
+  identityMode: IdentityModeSchema.optional(),
+  fingerprints: FingerprintsSchema.optional(),
 });
 
 const DescribeInput = z.object({
@@ -300,6 +439,7 @@ const DescribeOutput = z.object({
   previewFile: z.string().optional(),
   provenance: ProvenanceSchema.optional(),
   registry: RegistrySchema.optional(),
+  management: ManagementSchema,
 });
 
 const PreviewInput = z.object({
@@ -370,11 +510,26 @@ const SourceStatusInput = z.object({
     .max(2_000)
     .optional()
     .describe("FigureYa Source Pack directory; otherwise FIGUREYA_SOURCE_PACK_DIR is used."),
+  galleryDirectory: z
+    .string()
+    .min(1)
+    .max(2_000)
+    .optional()
+    .describe("Personal Gallery directory to inspect; otherwise FIGURE_GALLERY_DIR is used."),
 });
 
 const SourceStatusOutput = z.object({
   libraryDirectory: z.string(),
+  libraryDirectorySource: z.enum(["FIGURE_LIBRARY_DIR", "default"]),
+  galleryDirectory: z.string().optional(),
+  galleryDirectorySource: z.enum(["argument", "FIGURE_GALLERY_DIR", "unset"]),
+  galleryDirectoryAccessible: z.boolean(),
   userTemplateCount: z.number().int(),
+  activeUserTemplateCount: z.number().int(),
+  archivedUserTemplateCount: z.number().int(),
+  legacyTemplateCount: z.number().int(),
+  invalidTemplateCount: z.number().int(),
+  duplicateGroupCount: z.number().int(),
   figureYa: z.object({
     catalogTemplates: z.number().int(),
     sourcePackConfigured: z.boolean(),
@@ -385,6 +540,93 @@ const SourceStatusOutput = z.object({
     availableBytes: z.number().int(),
     archiveRevision: z.string(),
   }),
+});
+
+const AuditInput = z.object({
+  scope: z.enum(["duplicates", "legacy", "integrity", "all"]).optional().default("all"),
+  includeArchived: z.boolean().optional().default(true),
+});
+const AuditTemplateSchema = z.object({
+  templateId: z.string(),
+  title: z.string(),
+  reviewStatus: z.enum(["draft", "approved", "archived"]),
+  codeStatus: z.enum(["none", "scaffold", "reviewed"]),
+  importedAt: z.string(),
+  adapter: ImportAdapterSchema.optional(),
+  registrySourceId: z.string().optional(),
+  galleryId: z.string().optional(),
+  identityMode: IdentityModeSchema.optional(),
+  contentHash: z.string().optional(),
+  fingerprints: FingerprintsSchema,
+  manifestSha256: z.string(),
+  verifiedFileSetDigest: z.string(),
+  integrityStatus: z.literal("valid"),
+  legacy: z.boolean(),
+  management: ManagementSchema,
+  metadataCompleteness: z.number().int(),
+});
+const DiagnosticSchema = z.object({
+  directoryName: z.string(),
+  directory: z.string(),
+  templateId: z.string().optional(),
+  error: z.string(),
+});
+const AuditOutput = z.object({
+  scope: z.enum(["duplicates", "legacy", "integrity", "all"]),
+  includeArchived: z.boolean(),
+  libraryDirectory: z.string(),
+  userTemplateCount: z.number().int(),
+  legacyTemplateCount: z.number().int(),
+  invalidTemplateCount: z.number().int(),
+  duplicateGroupCount: z.number().int(),
+  invalid: z.array(DiagnosticSchema),
+  templates: z.array(AuditTemplateSchema),
+  duplicateGroups: z.array(
+    z.object({
+      groupId: z.string(),
+      templateIds: z.array(z.string()),
+      evidence: z.array(
+        z.object({ left: z.string(), right: z.string(), matchKinds: z.array(z.string()) }),
+      ),
+      recommendedCanonicalTemplateId: z.string(),
+      recommendationOnly: z.literal(true),
+    }),
+  ),
+});
+
+const ExpectedStateSchema = z.object({
+  manifestSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+  verifiedFileSetDigest: z.string().regex(/^[a-f0-9]{64}$/u),
+  reviewStatus: z.enum(["draft", "approved", "archived"]),
+});
+const ReconcileInput = z.object({
+  mode: z.enum(["dry-run", "apply", "rollback"]).optional().default("dry-run"),
+  reconcileId: z.string().min(1).max(100).regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/u),
+  canonicalTemplateId: z.string().min(1).max(200),
+  duplicateTemplateIds: z.array(z.string().min(1).max(200)).min(1),
+  strategy: z.literal("archive_duplicates"),
+  expectedState: z.record(z.string(), ExpectedStateSchema),
+  reason: z.string().min(1).max(2_000),
+});
+const ReconcileOutput = z.object({
+  reconcileId: z.string(),
+  mode: z.enum(["dry-run", "apply", "rollback"]),
+  strategy: z.literal("archive_duplicates").optional(),
+  canonicalTemplateId: z.string(),
+  duplicateTemplateIds: z.array(z.string()).optional(),
+  restoredTemplateIds: z.array(z.string()).optional(),
+  changes: z
+    .array(
+      z.object({
+        templateId: z.string(),
+        beforeReviewStatus: z.enum(["draft", "approved", "archived"]),
+        afterReviewStatus: z.literal("archived"),
+        retainedFiles: z.number().int(),
+      }),
+    )
+    .optional(),
+  filesRetained: z.number().int().optional(),
+  written: z.boolean(),
 });
 
 function candidateText(candidates: TemplateCandidate[]) {
@@ -568,7 +810,8 @@ export async function createServer() {
       description:
         "Copy a user-supplied figure/code or validate and import a Figure Transfer Package ZIP. " +
         "Transfer Packages enter as draft visual references. The tool never executes code or " +
-        "stores original absolute paths.",
+        "stores original absolute paths. Direct-write mode is retained for v0.2 compatibility; " +
+        "new Agents should use figure_library_plan_import and figure_library_apply_import.",
       inputSchema: ImportInput.shape,
       outputSchema: ImportOutput.shape,
       annotations: {
@@ -620,7 +863,7 @@ export async function createServer() {
                 `${result.template.templateId} at ${result.directory}. ${output.warning}`,
             },
           ],
-          structuredContent: output,
+          structuredContent: { ...output },
         };
       } catch (error) {
         return {
@@ -629,6 +872,105 @@ export async function createServer() {
             {
               type: "text",
               text: `User template import failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "figure_library_plan_import",
+    {
+      title: "Plan a direct user-template import",
+      description:
+        "Read and validate direct-import files, calculate stable identity and duplicate evidence, " +
+        "and return a concurrency-bound plan. No files are written.",
+      inputSchema: DirectImportInput.shape,
+      outputSchema: DirectImportPlanOutput.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input): Promise<CallToolResult> => {
+      try {
+        const output = await userLibrary.planDirectImport(input);
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `No files were written. ${output.action}: ${output.normalizedTitle} ` +
+                `would use ${output.proposedTemplateId}. Awaiting exact confirmation.`,
+            },
+          ],
+          structuredContent: { ...output },
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Direct import planning failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "figure_library_apply_import",
+    {
+      title: "Apply a confirmed direct import plan",
+      description:
+        "Revalidate a direct import plan and apply only the exact confirmed create/update/duplicate " +
+        "decision. Imported code is copied but never executed.",
+      inputSchema: DirectImportApplyInput.shape,
+      outputSchema: DirectImportApplyOutput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input): Promise<CallToolResult> => {
+      try {
+        const result = await userLibrary.applyDirectImport(input);
+        const output = {
+          templateId: result.template.templateId,
+          title: result.template.title,
+          directory: result.directory,
+          action: result.action,
+          replayed: result.replayed,
+          plan: result.plan,
+          warning: "Reference only. Imported code was copied but never executed.",
+        };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${result.replayed ? "Replayed safely" : "Applied"}: ${result.template.templateId}. ${output.warning}`,
+            },
+          ],
+          structuredContent: output,
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Confirmed direct import failed: ${
                 error instanceof Error ? error.message : String(error)
               }`,
             },
@@ -789,10 +1131,10 @@ export async function createServer() {
   server.registerTool(
     "figure_library_archive",
     {
-      title: "Logically archive an imported Gallery entry",
+      title: "Logically archive a user-library template",
       description:
-        "Mark an imported gallery_id archived so default search excludes it. Files are retained; " +
-        "this tool never hard-deletes a template.",
+        "Resolve a templateId, galleryId, or adapter-scoped registrySourceId and exclude the template " +
+        "from default search. Files are retained; this tool never hard-deletes a template.",
       inputSchema: ArchiveInput.shape,
       outputSchema: ArchiveOutput.shape,
       annotations: {
@@ -802,22 +1144,29 @@ export async function createServer() {
         openWorldHint: false,
       },
     },
-    async ({ galleryId }): Promise<CallToolResult> => {
+    async (reference): Promise<CallToolResult> => {
       try {
-        const result = await userLibrary.archiveGallery(galleryId);
+        const result = await userLibrary.archiveTemplate(reference);
+        const management = result.template.registry;
         const output = {
-          galleryId,
           templateId: result.template.templateId,
+          galleryId: management?.galleryId,
+          registrySourceId: management?.sourceId,
+          adapter: management?.adapter,
+          previousReviewStatus: result.previousReviewStatus,
           reviewStatus: "archived" as const,
           directory: result.directory,
-          existed: result.existed,
+          changed: result.changed,
+          alreadyArchived: result.alreadyArchived,
+          filesRetained: true as const,
+          existed: result.alreadyArchived,
           warning: "Logical archive only; reference files were retained.",
         };
         return {
           content: [
             {
               type: "text",
-              text: `${result.existed ? "Already archived" : "Archived"} ${galleryId}. ${output.warning}`,
+              text: `${result.alreadyArchived ? "Already archived" : "Archived"} ${result.template.templateId}. ${output.warning}`,
             },
           ],
           structuredContent: output,
@@ -828,7 +1177,7 @@ export async function createServer() {
           content: [
             {
               type: "text",
-              text: `Gallery archive failed: ${error instanceof Error ? error.message : String(error)}`,
+              text: `Template archive failed: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
         };
@@ -933,7 +1282,8 @@ export async function createServer() {
     {
       title: "Inspect figure template sources",
       description:
-        "Report the user-library count and inspect a local FigureYa Source Pack by file name and size.",
+        "Report effective User Library and Gallery paths, lifecycle/integrity counts, and inspect a " +
+        "local FigureYa Source Pack by file name and size.",
       inputSchema: SourceStatusInput.shape,
       outputSchema: SourceStatusOutput.shape,
       annotations: {
@@ -943,14 +1293,45 @@ export async function createServer() {
         openWorldHint: false,
       },
     },
-    async ({ sourcePackDir }): Promise<CallToolResult> => {
-      const [userTemplates, figureYa] = await Promise.all([
-        userLibrary.list(),
+    async ({ sourcePackDir, galleryDirectory: galleryArgument }): Promise<CallToolResult> => {
+      const galleryEnvironment = process.env.FIGURE_GALLERY_DIR?.trim();
+      const galleryDirectory = galleryArgument ?? galleryEnvironment;
+      let galleryDirectoryAccessible = false;
+      if (galleryDirectory) {
+        try {
+          const stat = await fs.lstat(path.resolve(galleryDirectory));
+          galleryDirectoryAccessible = stat.isDirectory() && !stat.isSymbolicLink();
+        } catch {
+          galleryDirectoryAccessible = false;
+        }
+      }
+      const [audit, figureYa] = await Promise.all([
+        userLibrary.auditTemplates({ scope: "all", includeArchived: true }),
         inspectFigureYaSourcePack(index.catalog, sourcePackDir),
       ]);
       const output = {
         libraryDirectory: userLibrary.root,
-        userTemplateCount: userTemplates.length,
+        libraryDirectorySource:
+          userLibrary.directorySource === "FIGURE_LIBRARY_DIR"
+            ? ("FIGURE_LIBRARY_DIR" as const)
+            : ("default" as const),
+        galleryDirectory: galleryDirectory ? path.resolve(galleryDirectory) : undefined,
+        galleryDirectorySource: galleryArgument
+          ? ("argument" as const)
+          : galleryEnvironment
+            ? ("FIGURE_GALLERY_DIR" as const)
+            : ("unset" as const),
+        galleryDirectoryAccessible,
+        userTemplateCount: audit.userTemplateCount,
+        activeUserTemplateCount: audit.templates.filter(
+          (item) => item.reviewStatus !== "archived",
+        ).length,
+        archivedUserTemplateCount: audit.templates.filter(
+          (item) => item.reviewStatus === "archived",
+        ).length,
+        legacyTemplateCount: audit.legacyTemplateCount,
+        invalidTemplateCount: audit.invalidTemplateCount,
+        duplicateGroupCount: audit.duplicateGroupCount,
         figureYa: {
           catalogTemplates: index.catalog.modules.length,
           sourcePackConfigured: figureYa.configured,
@@ -967,13 +1348,107 @@ export async function createServer() {
           {
             type: "text",
             text:
-              `${userTemplates.length} user templates; ${index.catalog.modules.length} FigureYa ` +
+              `${audit.userTemplateCount} user templates; ${audit.invalidTemplateCount} invalid; ` +
+              `${audit.duplicateGroupCount} duplicate groups; ${index.catalog.modules.length} FigureYa ` +
               `catalog templates; ${figureYa.availableTemplates.length} FigureYa archives available ` +
               "in the configured Source Pack.",
           },
         ],
         structuredContent: output,
       };
+    },
+  );
+
+  server.registerTool(
+    "figure_library_audit",
+    {
+      title: "Audit the User Library",
+      description:
+        "Read every user-template manifest, verify stored files, and report invalid, legacy, and " +
+        "component-level duplicate evidence. Recommendations never modify the library.",
+      inputSchema: AuditInput.shape,
+      outputSchema: AuditOutput.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input): Promise<CallToolResult> => {
+      try {
+        const output = await userLibrary.auditTemplates(input);
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `No files were written. ${output.userTemplateCount} valid templates, ` +
+                `${output.invalidTemplateCount} invalid, ${output.legacyTemplateCount} legacy, ` +
+                `${output.duplicateGroupCount} duplicate groups. Canonical IDs are recommendations only.`,
+            },
+          ],
+          structuredContent: output,
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `User Library audit failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "figure_library_reconcile",
+    {
+      title: "Reconcile duplicate user templates",
+      description:
+        "Dry-run, apply, or roll back an exact duplicate-archive transaction. Apply uses verified " +
+        "manifest/file preconditions, a shared write lock, and a recovery journal; files are retained.",
+      inputSchema: ReconcileInput.shape,
+      outputSchema: ReconcileOutput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (input): Promise<CallToolResult> => {
+      try {
+        const output = await userLibrary.reconcileTemplates(input);
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `${output.mode === "dry-run" ? "No files were written" : "Transaction recorded"}. ` +
+                `${output.reconcileId}: ${output.mode}. Template files were retained.`,
+            },
+          ],
+          structuredContent: output,
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Duplicate reconcile failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            },
+          ],
+        };
+      }
     },
   );
 
@@ -1025,6 +1500,11 @@ export async function createServer() {
           sourceRevision: index.catalog.figureya.commit,
           archiveRevision: index.catalog.compressed.commit,
           citation: index.catalog.citation,
+          management: {
+            templateId,
+            canArchive: false,
+            canUpdate: false,
+          },
         };
         return {
           content: [
@@ -1084,6 +1564,7 @@ export async function createServer() {
         previewFile: user.template.preview?.file,
         provenance: user.template.provenance,
         registry: user.template.registry,
+        management: managementReference(user.template),
       };
       return {
         content: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -615,6 +615,7 @@ const ReconcileOutput = z.object({
   canonicalTemplateId: z.string(),
   duplicateTemplateIds: z.array(z.string()).optional(),
   restoredTemplateIds: z.array(z.string()).optional(),
+  recoveredIncomplete: z.boolean().optional(),
   changes: z
     .array(
       z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,28 @@ export interface SearchRequest {
 export type AssetKind = "plot_template" | "visual_reference";
 export type ReviewStatus = "draft" | "approved" | "archived";
 export type CodeStatus = "none" | "scaffold" | "reviewed";
+export type ImportAdapter = "direct" | "gallery" | "figure-transfer-package";
+export type IdentityMode = "stable-source" | "content-addressed";
+
+export interface AssetFingerprintsV1 {
+  algorithm: "figure-library.asset-fingerprints.v1";
+  previewSha256?: string;
+  executableCodeSetSha256?: string;
+  dataSetSha256?: string;
+  metadataSetSha256?: string;
+  fullAssetSha256: string;
+}
+
+export interface ManagementReference {
+  templateId: string;
+  adapter?: ImportAdapter;
+  registrySourceId?: string;
+  galleryId?: string;
+  identityMode?: IdentityMode;
+  canArchive: boolean;
+  canUpdate: boolean;
+  updateVia?: "plan-apply" | "diff-upsert" | "gallery-sync";
+}
 
 export interface TemplateCandidate {
   templateId: string;
@@ -80,6 +102,7 @@ export interface TemplateCandidate {
   sourceUrl?: string;
   reportUrl?: string;
   previewDataUrl?: string;
+  management: ManagementReference;
 }
 
 export interface StoredFile {
@@ -118,12 +141,14 @@ export interface TemplateProvenance {
 }
 
 export interface ImportRegistryEntry {
-  adapter: "gallery" | "figure-transfer-package";
+  adapter: ImportAdapter;
   sourceId: string;
   templateId?: string;
   galleryId?: string;
   contentHash: string;
   sourceCommit?: string;
+  identityMode?: IdentityMode;
+  fingerprints?: AssetFingerprintsV1;
 }
 
 export interface UserTemplate {
@@ -168,4 +193,5 @@ export interface UserTemplateImport {
   provenance?: TemplateProvenance;
   imagePath?: string;
   codePaths?: string[];
+  sourceKey?: string;
 }

--- a/src/user-library.ts
+++ b/src/user-library.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { buildSearchIntent, scoreSearchableTemplate } from "./catalog.ts";
 import {
+  assetFingerprints,
   discoverGalleryEntries,
   EMBEDDABLE_IMAGE_TYPES,
   MAX_CODE_BYTES,
@@ -16,8 +17,11 @@ import {
   type PreparedTemplate,
 } from "./importers.ts";
 import type {
+  AssetFingerprintsV1,
   AssetKind,
   CodeStatus,
+  ImportAdapter,
+  ManagementReference,
   ReviewStatus,
   SearchRequest,
   StoredFile,
@@ -28,12 +32,12 @@ import type {
   UserTemplateImport,
 } from "./types.ts";
 
-interface LoadedTemplate {
+export interface LoadedTemplate {
   template: UserTemplate;
   directory: string;
 }
 
-function sha256(bytes: Uint8Array) {
+function sha256(bytes: Uint8Array | string) {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
@@ -51,6 +55,20 @@ function resolveStoredFile(directory: string, relative: string) {
   const root = `${path.resolve(directory)}${path.sep}`;
   if (!resolved.startsWith(root)) throw new Error(`unsafe stored file path: ${relative}`);
   return resolved;
+}
+
+function validFingerprints(value: unknown): value is AssetFingerprintsV1 {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<AssetFingerprintsV1>;
+  const optionalHash = (hash: unknown) => hash === undefined || /^[a-f0-9]{64}$/u.test(String(hash));
+  return (
+    item.algorithm === "figure-library.asset-fingerprints.v1" &&
+    optionalHash(item.previewSha256) &&
+    optionalHash(item.executableCodeSetSha256) &&
+    optionalHash(item.dataSetSha256) &&
+    optionalHash(item.metadataSetSha256) &&
+    /^[a-f0-9]{64}$/u.test(item.fullAssetSha256 ?? "")
+  );
 }
 
 function isUserTemplate(value: unknown): value is UserTemplate {
@@ -104,11 +122,14 @@ function isUserTemplate(value: unknown): value is UserTemplate {
     (item.codeStatus === undefined || codeStatuses.includes(item.codeStatus)) &&
     (registry === undefined ||
       (typeof registry.sourceId === "string" &&
-        ["gallery", "figure-transfer-package"].includes(registry.adapter) &&
+        ["direct", "gallery", "figure-transfer-package"].includes(registry.adapter) &&
         /^[a-f0-9]{64}$/u.test(registry.contentHash) &&
         (registry.templateId === undefined || registry.templateId === item.templateId) &&
         (registry.galleryId === undefined || typeof registry.galleryId === "string") &&
-        (registry.sourceCommit === undefined || typeof registry.sourceCommit === "string"))) &&
+        (registry.sourceCommit === undefined || typeof registry.sourceCommit === "string") &&
+        (registry.identityMode === undefined ||
+          ["stable-source", "content-addressed"].includes(registry.identityMode)) &&
+        (registry.fingerprints === undefined || validFingerprints(registry.fingerprints)))) &&
     (item.preview === undefined ||
       (storedFile(item.preview) && typeof item.preview.mediaType === "string")) &&
     [...item.code, ...references].reduce(
@@ -131,6 +152,35 @@ async function checkedStoredBytes(directory: string, stored: StoredFile, maxByte
     throw new Error(`stored reference checksum mismatch: ${stored.file}`);
   }
   return bytes;
+}
+
+export function managementReference(template: UserTemplate): ManagementReference {
+  const registry = template.registry;
+  if (!registry) {
+    return {
+      templateId: template.templateId,
+      canArchive: true,
+      canUpdate: false,
+    };
+  }
+  const updateVia =
+    registry.adapter === "gallery"
+      ? "gallery-sync"
+      : registry.adapter === "figure-transfer-package"
+        ? "diff-upsert"
+        : registry.adapter === "direct"
+          ? "plan-apply"
+          : undefined;
+  return {
+    templateId: template.templateId,
+    adapter: registry.adapter,
+    registrySourceId: registry.sourceId,
+    galleryId: registry.galleryId,
+    identityMode: registry.identityMode,
+    canArchive: true,
+    canUpdate: Boolean(updateVia),
+    updateVia,
+  };
 }
 
 function userCandidate(
@@ -170,6 +220,7 @@ function userCandidate(
     codeStatus: template.codeStatus ?? (template.code.length ? "reviewed" : "none"),
     license: template.license,
     sourceUrl: template.provenance?.url,
+    management: managementReference(template),
   } satisfies TemplateCandidate;
 }
 
@@ -221,7 +272,7 @@ export interface ImportChange {
 
 export interface ImportDiff {
   action: "create" | "unchanged" | "update" | "skipped";
-  adapter: "gallery" | "figure-transfer-package";
+  adapter: ImportAdapter;
   sourceId: string;
   galleryId?: string;
   templateId: string;
@@ -242,6 +293,80 @@ export interface GallerySyncOptions {
   plotFamily?: string;
   reviewStatus?: ReviewStatus;
   codeStatus?: CodeStatus;
+}
+
+export interface TemplateDiagnostic {
+  directoryName: string;
+  directory: string;
+  templateId?: string;
+  error: string;
+}
+
+export interface ScannedTemplate extends LoadedTemplate {
+  manifestSha256: string;
+  verifiedFileSetDigest: string;
+  fingerprints: AssetFingerprintsV1;
+  legacy: boolean;
+}
+
+export interface TemplateScan {
+  valid: ScannedTemplate[];
+  invalid: TemplateDiagnostic[];
+}
+
+export type DirectImportAction =
+  | "create"
+  | "unchanged"
+  | "update"
+  | "duplicate_candidate"
+  | "source_conflict";
+
+export interface DirectImportMatch {
+  templateId: string;
+  title: string;
+  matchKinds: string[];
+  manifestSha256: string;
+}
+
+export interface DirectImportPlan {
+  action: DirectImportAction;
+  normalizedTitle: string;
+  proposedTemplateId: string;
+  registrySourceId: string;
+  identityMode: "stable-source" | "content-addressed";
+  fingerprints: AssetFingerprintsV1;
+  contentHash: string;
+  changes: ImportChange[];
+  matches: DirectImportMatch[];
+  planDigest: string;
+  written: false;
+}
+
+export interface DirectImportApplyInput extends UserTemplateImport {
+  planDigest: string;
+  expectedAction: DirectImportAction;
+  expectedTemplateId: string;
+  operationId: string;
+  duplicateResolution?:
+    | { action: "reuse"; templateId: string; reason: string }
+    | { action: "create_separate"; reason: string };
+  sourceConflictResolution?: { action: "replace_source"; reason: string };
+}
+
+export interface ReconcileExpectedState {
+  manifestSha256: string;
+  verifiedFileSetDigest: string;
+  reviewStatus: ReviewStatus;
+}
+
+export interface ReconcileInput {
+  mode?: "dry-run" | "apply" | "rollback";
+  reconcileId: string;
+  canonicalTemplateId: string;
+  duplicateTemplateIds: string[];
+  strategy: "archive_duplicates";
+  expectedState: Record<string, ReconcileExpectedState>;
+  reason: string;
 }
 
 function comparable(value: unknown): unknown {
@@ -361,55 +486,594 @@ function provenanceMarkdown(template: UserTemplate) {
   return lines.length ? `\n## Provenance\n\n${lines.join("\n")}\n\n` : "\n";
 }
 
+function templateFingerprints(template: UserTemplate) {
+  return (
+    template.registry?.fingerprints ??
+    assetFingerprints(template.preview, template.code, template.references ?? [])
+  );
+}
+
+function verifiedDescriptorDigest(template: UserTemplate) {
+  const descriptors = [
+    ...(template.preview ? [{ role: "preview", ...template.preview }] : []),
+    ...template.code.map((file) => ({ role: "code", ...file })),
+    ...(template.references ?? []).map((file) => ({ ...file, role: file.role })),
+  ].sort(
+    (left, right) => left.role.localeCompare(right.role) || left.file.localeCompare(right.file),
+  );
+  return sha256(JSON.stringify(descriptors));
+}
+
+function normalizedTitle(value: string) {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+function componentMatchKinds(
+  left: AssetFingerprintsV1,
+  right: AssetFingerprintsV1,
+  leftTitle?: string,
+  rightTitle?: string,
+) {
+  const kinds: string[] = [];
+  if (left.fullAssetSha256 === right.fullAssetSha256) kinds.push("same_full_asset");
+  if (left.previewSha256 && left.previewSha256 === right.previewSha256) kinds.push("same_preview");
+  if (
+    left.executableCodeSetSha256 &&
+    left.executableCodeSetSha256 === right.executableCodeSetSha256
+  ) {
+    kinds.push("same_executable_code");
+  }
+  if (left.dataSetSha256 && left.dataSetSha256 === right.dataSetSha256) kinds.push("same_data");
+  if (left.metadataSetSha256 && left.metadataSetSha256 === right.metadataSetSha256) {
+    kinds.push("same_metadata");
+  }
+  if (
+    kinds.some((kind) =>
+      ["same_preview", "same_executable_code", "same_data", "same_metadata"].includes(kind),
+    ) &&
+    !kinds.includes("same_full_asset")
+  ) {
+    kinds.push("partial_component_overlap");
+  }
+  if (
+    leftTitle !== undefined &&
+    rightTitle !== undefined &&
+    normalizedTitle(leftTitle) === normalizedTitle(rightTitle)
+  ) {
+    kinds.push("similar_title");
+  }
+  return kinds;
+}
+
+function hasStrongAssetContinuity(kinds: string[]) {
+  return kinds.some((kind) =>
+    ["same_full_asset", "same_preview", "same_executable_code", "same_data"].includes(kind),
+  );
+}
+
 export class UserTemplateLibrary {
   readonly root: string;
   readonly templatesDirectory: string;
+  readonly directorySource: "argument" | "FIGURE_LIBRARY_DIR" | "default";
+  readonly writeLockDirectory: string;
+  readonly transactionsDirectory: string;
 
-  constructor(root = process.env.FIGURE_LIBRARY_DIR?.trim() || path.join(os.homedir(), ".figure-library")) {
-    this.root = path.resolve(root);
+  constructor(root?: string) {
+    const environmentRoot = process.env.FIGURE_LIBRARY_DIR?.trim() || undefined;
+    const selected = root ?? environmentRoot ?? path.join(os.homedir(), ".figure-library");
+    this.directorySource = root ? "argument" : environmentRoot ? "FIGURE_LIBRARY_DIR" : "default";
+    this.root = path.resolve(selected);
     this.templatesDirectory = path.join(this.root, "templates");
+    this.writeLockDirectory = path.join(this.root, ".write-lock");
+    this.transactionsDirectory = path.join(this.root, "transactions");
   }
 
-  async list(): Promise<LoadedTemplate[]> {
+  private async incompleteTransactions() {
     let entries;
     try {
-      entries = await fs.readdir(this.templatesDirectory, { withFileTypes: true });
+      entries = await fs.readdir(this.transactionsDirectory, { withFileTypes: true });
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
       throw error;
     }
+    const incomplete = [];
+    for (const entry of entries.filter((item) => item.isDirectory())) {
+      try {
+        const journal = JSON.parse(
+          await fs.readFile(path.join(this.transactionsDirectory, entry.name, "journal.json"), "utf8"),
+        ) as { status?: string };
+        if (journal.status !== "committed" && journal.status !== "rolled-back") {
+          incomplete.push(entry.name);
+        }
+      } catch {
+        incomplete.push(entry.name);
+      }
+    }
+    return incomplete.sort();
+  }
 
-    const templates = await Promise.all(
-      entries
-        .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
-        .map(async (entry) => {
-          const directory = path.join(this.templatesDirectory, entry.name);
-          try {
-            const value = JSON.parse(
-              await fs.readFile(path.join(directory, "template.json"), "utf8"),
-            ) as unknown;
-            if (!isUserTemplate(value) || value.templateId !== entry.name) return;
-            return { template: value, directory };
-          } catch {
-            return;
+  private async withWriteLock<T>(operation: string, callback: () => Promise<T>) {
+    await fs.mkdir(this.root, { recursive: true });
+    try {
+      await fs.mkdir(this.writeLockDirectory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        let owner = "unknown writer";
+        try {
+          owner = await fs.readFile(path.join(this.writeLockDirectory, "owner.json"), "utf8");
+        } catch {
+          // Preserve a missing/corrupt lock for manual recovery.
+        }
+        throw new Error(`user library is write-locked; manual recovery required: ${owner}`);
+      }
+      throw error;
+    }
+    try {
+      await fs.writeFile(
+        path.join(this.writeLockDirectory, "owner.json"),
+        `${JSON.stringify({ operation, pid: process.pid, createdAt: new Date().toISOString() }, null, 2)}\n`,
+        { flag: "wx" },
+      );
+      const incomplete = await this.incompleteTransactions();
+      if (incomplete.length) {
+        throw new Error(
+          `incomplete user-library transaction requires recovery: ${incomplete.join(", ")}`,
+        );
+      }
+      return await callback();
+    } finally {
+      await fs.rm(this.writeLockDirectory, { recursive: true, force: true });
+    }
+  }
+
+  async scanTemplates(options: { verifyFiles?: boolean } = {}): Promise<TemplateScan> {
+    let entries;
+    try {
+      entries = await fs.readdir(this.templatesDirectory, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return { valid: [], invalid: [] };
+      throw error;
+    }
+    const valid: ScannedTemplate[] = [];
+    const invalid: TemplateDiagnostic[] = [];
+    for (const entry of entries.filter((item) => !item.name.startsWith("."))) {
+      const directory = path.join(this.templatesDirectory, entry.name);
+      if (!entry.isDirectory()) {
+        invalid.push({ directoryName: entry.name, directory, error: "template entry is not a directory" });
+        continue;
+      }
+      let value: unknown;
+      let manifestText: string;
+      try {
+        manifestText = await fs.readFile(path.join(directory, "template.json"), "utf8");
+        value = JSON.parse(manifestText) as unknown;
+      } catch (error) {
+        invalid.push({
+          directoryName: entry.name,
+          directory,
+          error: `template manifest is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+        });
+        continue;
+      }
+      const templateId =
+        value && typeof value === "object" && "templateId" in value
+          ? String((value as { templateId?: unknown }).templateId ?? "") || undefined
+          : undefined;
+      if (!isUserTemplate(value)) {
+        invalid.push({ directoryName: entry.name, directory, templateId, error: "invalid template schema" });
+        continue;
+      }
+      if (value.templateId !== entry.name) {
+        invalid.push({
+          directoryName: entry.name,
+          directory,
+          templateId: value.templateId,
+          error: "templateId does not match directory name",
+        });
+        continue;
+      }
+      try {
+        for (const stored of [
+          ...(value.preview ? [value.preview] : []),
+          ...value.code,
+          ...(value.references ?? []),
+        ]) {
+          resolveStoredFile(directory, stored.file);
+          if (options.verifyFiles) {
+            await checkedStoredBytes(
+              directory,
+              stored,
+              stored === value.preview ? MAX_IMAGE_BYTES : MAX_CODE_BYTES,
+            );
           }
-        }),
-    );
-    return templates
-      .filter((item): item is LoadedTemplate => Boolean(item))
-      .sort((left, right) => left.template.templateId.localeCompare(right.template.templateId));
+        }
+      } catch (error) {
+        invalid.push({
+          directoryName: entry.name,
+          directory,
+          templateId: value.templateId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+      const computedFingerprints = assetFingerprints(
+        value.preview,
+        value.code,
+        value.references ?? [],
+      );
+      if (
+        value.registry?.fingerprints &&
+        JSON.stringify(comparable(value.registry.fingerprints)) !==
+          JSON.stringify(comparable(computedFingerprints))
+      ) {
+        invalid.push({
+          directoryName: entry.name,
+          directory,
+          templateId: value.templateId,
+          error: "registry component fingerprints do not match the verified stored files",
+        });
+        continue;
+      }
+      valid.push({
+        template: value,
+        directory,
+        manifestSha256: sha256(manifestText),
+        verifiedFileSetDigest: verifiedDescriptorDigest(value),
+        fingerprints: computedFingerprints,
+        legacy: !value.registry,
+      });
+    }
+    valid.sort((left, right) => left.template.templateId.localeCompare(right.template.templateId));
+    invalid.sort((left, right) => left.directoryName.localeCompare(right.directoryName));
+    return { valid, invalid };
+  }
+
+  async list(): Promise<LoadedTemplate[]> {
+    const scan = await this.scanTemplates();
+    return scan.valid.map(({ template, directory }) => ({ template, directory }));
   }
 
   async get(templateId: string) {
     return (await this.list()).find((item) => item.template.templateId === templateId);
   }
 
+  private async directAlias(registrySourceId: string) {
+    try {
+      const lines = (await fs.readFile(path.join(this.root, "migrations", "aliases.jsonl"), "utf8"))
+        .split(/\r?\n/u)
+        .filter(Boolean);
+      for (const line of lines.reverse()) {
+        const value = JSON.parse(line) as {
+          adapter?: string;
+          registrySourceId?: string;
+          canonicalTemplateId?: string;
+        };
+        if (
+          value.adapter === "direct" &&
+          value.registrySourceId === registrySourceId &&
+          value.canonicalTemplateId
+        ) {
+          return value.canonicalTemplateId;
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    return undefined;
+  }
+
+  private async preparedDirectPlan(input: UserTemplateImport) {
+    const prepared = await prepareDirectImport(input);
+    const registry = prepared.registry;
+    if (!registry || registry.adapter !== "direct" || !registry.fingerprints) {
+      throw new Error("direct import preparation did not produce a stable registry");
+    }
+    const scan = await this.scanTemplates({ verifyFiles: true });
+    if (
+      scan.invalid.some(
+        (item) =>
+          item.directoryName === prepared.templateId || item.directoryName === prepared.legacyTemplateId,
+      )
+    ) {
+      throw new Error("direct import target collides with an invalid existing template directory");
+    }
+    const aliasedTemplateId = await this.directAlias(registry.sourceId);
+    const matches = scan.valid
+      .map((item) => {
+        const kinds = componentMatchKinds(
+          registry.fingerprints!,
+          item.fingerprints,
+          prepared.title,
+          item.template.title,
+        );
+        if (
+          item.template.registry?.adapter === "direct" &&
+          item.template.registry.sourceId === registry.sourceId
+        ) {
+          kinds.unshift("same_source");
+        }
+        if (
+          item.template.registry?.contentHash &&
+          item.template.registry.contentHash === prepared.contentHash
+        ) {
+          kinds.push("same_content");
+        }
+        if (prepared.legacyTemplateId === item.template.templateId) kinds.push("legacy_template_id");
+        if (aliasedTemplateId === item.template.templateId) kinds.unshift("source_alias");
+        return { item, kinds: [...new Set(kinds)] };
+      })
+      .filter(({ kinds }) => kinds.length > 0);
+    const sourceMatches = matches.filter(({ kinds }) => kinds.includes("same_source"));
+    const aliasMatches = matches.filter(({ kinds }) => kinds.includes("source_alias"));
+    if (sourceMatches.length > 1) {
+      throw new Error(
+        `direct source registry resolves to multiple templates: ${sourceMatches
+          .map(({ item }) => item.template.templateId)
+          .join(", ")}`,
+      );
+    }
+    if (aliasMatches.length > 1) {
+      throw new Error(
+        `direct source alias resolves to multiple templates: ${aliasMatches
+          .map(({ item }) => item.template.templateId)
+          .join(", ")}`,
+      );
+    }
+    if (
+      sourceMatches[0] &&
+      aliasMatches[0] &&
+      sourceMatches[0].item.template.templateId !== aliasMatches[0].item.template.templateId
+    ) {
+      throw new Error(
+        `direct source registry and alias disagree: ${sourceMatches[0].item.template.templateId}, ` +
+          aliasMatches[0].item.template.templateId,
+      );
+    }
+    const legacyMatch = matches.find(({ kinds }) => kinds.includes("legacy_template_id"));
+    const registeredSourceMatch = sourceMatches[0];
+    const aliasMatch = aliasMatches[0];
+    const logical = registeredSourceMatch ?? aliasMatch ?? legacyMatch;
+    const changes = logical ? changedFields(logical.item.template, prepared) : [];
+    let action: DirectImportAction;
+    let proposedTemplateId = prepared.templateId;
+    if (registeredSourceMatch) {
+      const existing = registeredSourceMatch;
+      proposedTemplateId = existing.item.template.templateId;
+      if (
+        existing.item.template.registry?.contentHash === prepared.contentHash &&
+        changes.length === 0
+      ) {
+        action = "unchanged";
+      } else if (
+        registry.identityMode === "content-addressed" ||
+        hasStrongAssetContinuity(existing.kinds)
+      ) {
+        action = "update";
+      } else {
+        action = "source_conflict";
+      }
+    } else if (aliasMatch) {
+      if (
+        aliasMatch.item.fingerprints.fullAssetSha256 === registry.fingerprints.fullAssetSha256
+      ) {
+        // A reuse decision intentionally keeps the canonical template's metadata and registry.
+        action = "unchanged";
+        proposedTemplateId = aliasMatch.item.template.templateId;
+      } else {
+        // Replacing a reused source must branch away from the canonical template rather than
+        // overwrite the canonical template owned by another Registry source.
+        action = "source_conflict";
+      }
+    } else if (
+      legacyMatch &&
+      legacyMatch.item.fingerprints.fullAssetSha256 === registry.fingerprints.fullAssetSha256 &&
+      changes.length === 0
+    ) {
+      action = "unchanged";
+      proposedTemplateId = legacyMatch.item.template.templateId;
+    } else if (matches.some(({ kinds }) => kinds.includes("same_full_asset"))) {
+      action = "duplicate_candidate";
+    } else {
+      action = "create";
+    }
+    const publicMatches: DirectImportMatch[] = matches
+      .map(({ item, kinds }) => ({
+        templateId: item.template.templateId,
+        title: item.template.title,
+        matchKinds: kinds,
+        manifestSha256: item.manifestSha256,
+      }))
+      .sort((left, right) => left.templateId.localeCompare(right.templateId));
+    const planPayload = {
+      action,
+      normalizedTitle: prepared.title,
+      proposedTemplateId,
+      registrySourceId: registry.sourceId,
+      identityMode: registry.identityMode ?? "content-addressed",
+      fingerprints: registry.fingerprints,
+      contentHash: prepared.contentHash,
+      changes,
+      matches: publicMatches,
+    };
+    const plan: DirectImportPlan = {
+      ...planPayload,
+      planDigest: sha256(JSON.stringify(comparable(planPayload))),
+      written: false,
+    };
+    return { prepared, plan, scan };
+  }
+
+  async planDirectImport(input: UserTemplateImport) {
+    return (await this.preparedDirectPlan(input)).plan;
+  }
+
+  private async appendAlias(record: {
+    operationId: string;
+    adapter: "direct";
+    registrySourceId: string;
+    canonicalTemplateId: string;
+    reason: string;
+  }) {
+    const directory = path.join(this.root, "migrations");
+    await fs.mkdir(directory, { recursive: true });
+    await fs.appendFile(
+      path.join(directory, "aliases.jsonl"),
+      `${JSON.stringify({ ...record, createdAt: new Date().toISOString() })}\n`,
+    );
+  }
+
+  private async appendDuplicateDecision(record: {
+    operationId: string;
+    registrySourceId: string;
+    templateId: string;
+    duplicateOf: string[];
+    reason: string;
+  }) {
+    const directory = path.join(this.root, "migrations");
+    await fs.mkdir(directory, { recursive: true });
+    await fs.appendFile(
+      path.join(directory, "duplicate-decisions.jsonl"),
+      `${JSON.stringify({ ...record, createdAt: new Date().toISOString() })}\n`,
+    );
+  }
+
+  private async appendSourceConflictDecision(record: {
+    operationId: string;
+    registrySourceId: string;
+    templateId: string;
+    reason: string;
+  }) {
+    const directory = path.join(this.root, "migrations");
+    await fs.mkdir(directory, { recursive: true });
+    await fs.appendFile(
+      path.join(directory, "source-conflict-decisions.jsonl"),
+      `${JSON.stringify({ ...record, createdAt: new Date().toISOString() })}\n`,
+    );
+  }
+
+  async applyDirectImport(input: DirectImportApplyInput) {
+    return this.withWriteLock(`direct-apply:${input.operationId}`, async () => {
+      const {
+        planDigest,
+        expectedAction,
+        expectedTemplateId,
+        operationId,
+        duplicateResolution,
+        sourceConflictResolution,
+        ...direct
+      } = input;
+      const { prepared, plan } = await this.preparedDirectPlan(direct);
+      if (
+        expectedAction === "create" &&
+        plan.action === "unchanged" &&
+        plan.proposedTemplateId === expectedTemplateId
+      ) {
+        const existing = await this.get(expectedTemplateId);
+        if (!existing) throw new Error("safe replay target disappeared");
+        return { ...existing, action: "unchanged" as const, replayed: true, plan };
+      }
+      if (plan.planDigest !== planDigest) {
+        throw new Error("stale import plan: input files or user-library state changed");
+      }
+      if (plan.action !== expectedAction || plan.proposedTemplateId !== expectedTemplateId) {
+        throw new Error("stale import plan: expected action or template ID changed");
+      }
+      if (plan.action === "unchanged") {
+        const existing = await this.get(expectedTemplateId);
+        if (!existing) throw new Error("unchanged import target disappeared");
+        return { ...existing, action: "unchanged" as const, replayed: false, plan };
+      }
+      if (plan.action === "duplicate_candidate") {
+        if (!duplicateResolution) {
+          throw new Error("duplicate candidate requires an explicit reuse or create_separate decision");
+        }
+        if (!duplicateResolution.reason.trim()) throw new Error("duplicate decision requires a reason");
+        if (duplicateResolution.action === "reuse") {
+          const canonical = await this.get(duplicateResolution.templateId);
+          if (
+            !canonical ||
+            !plan.matches.some((item) => item.templateId === duplicateResolution.templateId)
+          ) {
+            throw new Error("reuse target is not one of the planned duplicate matches");
+          }
+          await this.appendAlias({
+            operationId,
+            adapter: "direct",
+            registrySourceId: plan.registrySourceId,
+            canonicalTemplateId: canonical.template.templateId,
+            reason: duplicateResolution.reason.trim(),
+          });
+          return {
+            ...canonical,
+            action: "reused" as const,
+            replayed: false,
+            plan,
+          };
+        }
+      }
+      if (plan.action === "source_conflict") {
+        if (
+          sourceConflictResolution?.action !== "replace_source" ||
+          !sourceConflictResolution.reason.trim()
+        ) {
+          throw new Error("source conflict requires an explicit replace_source decision and reason");
+        }
+      }
+      const createSeparate =
+        plan.action === "duplicate_candidate" &&
+        duplicateResolution?.action === "create_separate";
+      const aliasBreakout =
+        plan.action === "source_conflict" &&
+        plan.matches.some((item) => item.matchKinds.includes("source_alias")) &&
+        !plan.matches.some((item) => item.matchKinds.includes("same_source"));
+      if (aliasBreakout && sourceConflictResolution) {
+        await this.appendAlias({
+          operationId,
+          adapter: "direct",
+          registrySourceId: plan.registrySourceId,
+          canonicalTemplateId: prepared.templateId,
+          reason: sourceConflictResolution.reason.trim(),
+        });
+      }
+      const result = await this.applyPrepared(
+        createSeparate || aliasBreakout ? { ...prepared, legacyTemplateId: undefined } : prepared,
+        true,
+      );
+      if (plan.action === "duplicate_candidate" && duplicateResolution?.action === "create_separate") {
+        await this.appendDuplicateDecision({
+          operationId,
+          registrySourceId: plan.registrySourceId,
+          templateId: result.template.templateId,
+          duplicateOf: plan.matches.map((item) => item.templateId),
+          reason: duplicateResolution.reason.trim(),
+        });
+      }
+      if (plan.action === "source_conflict" && sourceConflictResolution) {
+        await this.appendSourceConflictDecision({
+          operationId,
+          registrySourceId: plan.registrySourceId,
+          templateId: result.template.templateId,
+          reason: sourceConflictResolution.reason.trim(),
+        });
+      }
+      return { ...result, replayed: false, plan };
+    });
+  }
+
   async importTemplate(input: UserTemplateImport) {
-    return this.applyPrepared(await prepareDirectImport(input), false);
+    return this.withWriteLock("direct-import", async () =>
+      this.applyPrepared(await prepareDirectImport(input), false),
+    );
   }
 
   async importTransferPackage(packagePath: string) {
-    return this.applyPrepared(await prepareTransferPackage(packagePath), false);
+    return this.withWriteLock("transfer-import", async () =>
+      this.applyPrepared(await prepareTransferPackage(packagePath), false),
+    );
   }
 
   private async findPrepared(prepared: PreparedTemplate) {
@@ -422,7 +1086,11 @@ export class UserTemplateLibrary {
             template.registry.sourceId === registry.sourceId,
         )
       : undefined;
-    const byId = templates.find(({ template }) => template.templateId === prepared.templateId);
+    const byId = templates.find(
+      ({ template }) =>
+        template.templateId === prepared.templateId ||
+        (prepared.legacyTemplateId !== undefined && template.templateId === prepared.legacyTemplateId),
+    );
     if (byRegistry && byId && byRegistry.directory !== byId.directory) {
       throw new Error(`import registry conflict for ${prepared.registry?.sourceId}`);
     }
@@ -430,7 +1098,8 @@ export class UserTemplateLibrary {
     if (
       existing &&
       prepared.registry &&
-      (existing.template.registry?.adapter !== prepared.registry.adapter ||
+      existing.template.registry &&
+      (existing.template.registry.adapter !== prepared.registry.adapter ||
         existing.template.registry.sourceId !== prepared.registry.sourceId)
     ) {
       throw new Error(`template ID collision: ${prepared.templateId}`);
@@ -466,7 +1135,9 @@ export class UserTemplateLibrary {
   }
 
   async upsertImportSource(input: ImportSourceInput) {
-    return this.applyPrepared(await prepareImportSource(input), true);
+    return this.withWriteLock("source-upsert", async () =>
+      this.applyPrepared(await prepareImportSource(input), true),
+    );
   }
 
   private async writePrepared(prepared: PreparedTemplate, existing?: LoadedTemplate) {
@@ -554,8 +1225,43 @@ export class UserTemplateLibrary {
     }
   }
 
+  private async replaceManifest(directory: string, template: UserTemplate) {
+    const temporary = path.join(directory, `.template-${randomUUID()}.json`);
+    const manifest = path.join(directory, "template.json");
+    const backup = path.join(directory, `.template-backup-${randomUUID()}.json`);
+    await fs.writeFile(temporary, `${JSON.stringify(template, null, 2)}\n`, { flag: "wx" });
+    try {
+      await fs.rename(manifest, backup);
+      try {
+        await fs.rename(temporary, manifest);
+      } catch (error) {
+        await fs.rename(backup, manifest);
+        throw error;
+      }
+      await fs.rm(backup, { force: true });
+    } catch (error) {
+      await fs.rm(temporary, { force: true });
+      throw error;
+    }
+  }
+
   private async applyPrepared(prepared: PreparedTemplate, allowUpdate: boolean) {
     const existing = await this.findPrepared(prepared);
+    if (
+      prepared.registry?.adapter === "direct" &&
+      existing &&
+      !existing.template.registry &&
+      changedFields(existing.template, prepared).length === 0 &&
+      templateFingerprints(existing.template).fullAssetSha256 ===
+        prepared.registry.fingerprints?.fullAssetSha256
+    ) {
+      return {
+        template: existing.template,
+        directory: existing.directory,
+        existed: true,
+        action: "unchanged" as const,
+      };
+    }
     if (!prepared.registry && existing) {
       return {
         template: existing.template,
@@ -590,6 +1296,11 @@ export class UserTemplateLibrary {
   }
 
   async syncGallery(options: GallerySyncOptions) {
+    if (options.dryRun) return this.syncGalleryUnlocked(options);
+    return this.withWriteLock("gallery-sync", async () => this.syncGalleryUnlocked(options));
+  }
+
+  private async syncGalleryUnlocked(options: GallerySyncOptions) {
     const entries = await discoverGalleryEntries(options.galleryDirectory);
     const results: ImportDiff[] = [];
     for (const entry of entries) {
@@ -618,39 +1329,547 @@ export class UserTemplateLibrary {
     };
   }
 
-  async archiveGallery(galleryId: string) {
-    const loaded = (await this.list()).find(
-      ({ template }) => template.registry?.galleryId === galleryId,
+  async resolveTemplateReference(reference: {
+    templateId?: string;
+    galleryId?: string;
+    registrySourceId?: string;
+    adapter?: ImportAdapter;
+  }) {
+    const kinds = [reference.templateId, reference.galleryId, reference.registrySourceId].filter(
+      (value) => value !== undefined,
     );
-    if (!loaded) throw new Error(`unknown imported gallery_id: ${galleryId}`);
-    if (loaded.template.reviewStatus === "archived") {
-      return { template: loaded.template, directory: loaded.directory, existed: true };
+    if (kinds.length !== 1) {
+      throw new Error("provide exactly one of templateId, galleryId, or registrySourceId + adapter");
     }
-    const now = new Date().toISOString();
-    const template: UserTemplate = {
-      ...loaded.template,
-      reviewStatus: "archived",
-      archivedAt: now,
-      updatedAt: now,
+    if (reference.registrySourceId && !reference.adapter) {
+      throw new Error("adapter is required with registrySourceId");
+    }
+    const matches = (await this.list()).filter(({ template }) => {
+      if (reference.templateId) return template.templateId === reference.templateId;
+      if (reference.galleryId) return template.registry?.galleryId === reference.galleryId;
+      return (
+        template.registry?.adapter === reference.adapter &&
+        template.registry?.sourceId === reference.registrySourceId
+      );
+    });
+    if (matches.length === 0) {
+      throw new Error(
+        "unknown template reference; accepted references are templateId, galleryId, or registrySourceId + adapter",
+      );
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `template reference is ambiguous: ${matches.map((item) => item.template.templateId).join(", ")}`,
+      );
+    }
+    return matches[0]!;
+  }
+
+  async archiveTemplate(reference: {
+    templateId?: string;
+    galleryId?: string;
+    registrySourceId?: string;
+    adapter?: ImportAdapter;
+  }) {
+    return this.withWriteLock("template-archive", async () => {
+      const loaded = await this.resolveTemplateReference(reference);
+      const previousReviewStatus = loaded.template.reviewStatus ?? "approved";
+      if (previousReviewStatus === "archived") {
+        return {
+          template: loaded.template,
+          directory: loaded.directory,
+          previousReviewStatus,
+          changed: false,
+          alreadyArchived: true,
+          filesRetained: true as const,
+        };
+      }
+      const now = new Date().toISOString();
+      const template: UserTemplate = {
+        ...loaded.template,
+        reviewStatus: "archived",
+        archivedAt: now,
+        updatedAt: now,
+      };
+      await this.replaceManifest(loaded.directory, template);
+      return {
+        template,
+        directory: loaded.directory,
+        previousReviewStatus,
+        changed: true,
+        alreadyArchived: false,
+        filesRetained: true as const,
+      };
+    });
+  }
+
+  async archiveGallery(galleryId: string) {
+    const result = await this.archiveTemplate({ galleryId });
+    return { ...result, existed: result.alreadyArchived };
+  }
+
+  async auditTemplates(options: {
+    scope?: "duplicates" | "legacy" | "integrity" | "all";
+    includeArchived?: boolean;
+  } = {}) {
+    const scope = options.scope ?? "all";
+    const includeArchived = options.includeArchived ?? true;
+    const scan = await this.scanTemplates({ verifyFiles: true });
+    const visible = scan.valid.filter(
+      (item) => includeArchived || (item.template.reviewStatus ?? "approved") !== "archived",
+    );
+    const nodes = visible.map((item) => ({
+      templateId: item.template.templateId,
+      title: item.template.title,
+      reviewStatus: item.template.reviewStatus ?? "approved",
+      codeStatus: item.template.codeStatus ?? (item.template.code.length ? "reviewed" : "none"),
+      importedAt: item.template.importedAt,
+      adapter: item.template.registry?.adapter,
+      registrySourceId: item.template.registry?.sourceId,
+      galleryId: item.template.registry?.galleryId,
+      identityMode: item.template.registry?.identityMode,
+      contentHash: item.template.registry?.contentHash,
+      fingerprints: item.fingerprints,
+      manifestSha256: item.manifestSha256,
+      verifiedFileSetDigest: item.verifiedFileSetDigest,
+      integrityStatus: "valid" as const,
+      legacy: item.legacy,
+      management: managementReference(item.template),
+      metadataCompleteness: [
+        item.template.title,
+        item.template.description,
+        item.template.visualProfile,
+        item.template.dataProfile,
+        item.template.license,
+        item.template.provenance,
+      ].filter(Boolean).length,
+    }));
+    const edges: Array<{ left: string; right: string; matchKinds: string[] }> = [];
+    for (let leftIndex = 0; leftIndex < visible.length; leftIndex += 1) {
+      for (let rightIndex = leftIndex + 1; rightIndex < visible.length; rightIndex += 1) {
+        const left = visible[leftIndex]!;
+        const right = visible[rightIndex]!;
+        const kinds = componentMatchKinds(
+          left.fingerprints,
+          right.fingerprints,
+          left.template.title,
+          right.template.title,
+        );
+        if (
+          left.template.registry &&
+          right.template.registry &&
+          left.template.registry.adapter === right.template.registry.adapter &&
+          left.template.registry.sourceId === right.template.registry.sourceId
+        ) {
+          kinds.unshift("same_source");
+        }
+        if (
+          left.template.registry?.contentHash &&
+          left.template.registry.contentHash === right.template.registry?.contentHash
+        ) {
+          kinds.push("same_content");
+        }
+        if (kinds.length) {
+          edges.push({
+            left: left.template.templateId,
+            right: right.template.templateId,
+            matchKinds: [...new Set(kinds)],
+          });
+        }
+      }
+    }
+    const parent = new Map(nodes.map((node) => [node.templateId, node.templateId]));
+    const find = (id: string): string => {
+      const current = parent.get(id) ?? id;
+      if (current === id) return id;
+      const root = find(current);
+      parent.set(id, root);
+      return root;
     };
-    const temporary = path.join(loaded.directory, `.template-${randomUUID()}.json`);
-    const manifest = path.join(loaded.directory, "template.json");
-    const backup = path.join(loaded.directory, `.template-backup-${randomUUID()}.json`);
-    await fs.writeFile(temporary, `${JSON.stringify(template, null, 2)}\n`, { flag: "wx" });
-    try {
-      await fs.rename(manifest, backup);
+    const union = (left: string, right: string) => {
+      const leftRoot = find(left);
+      const rightRoot = find(right);
+      if (leftRoot !== rightRoot) parent.set(rightRoot, leftRoot);
+    };
+    for (const edge of edges) {
+      if (
+        edge.matchKinds.some((kind) => kind === "same_source" || kind === "same_content") ||
+        hasStrongAssetContinuity(edge.matchKinds)
+      ) {
+        union(edge.left, edge.right);
+      }
+    }
+    const grouped = new Map<string, typeof nodes>();
+    for (const node of nodes) {
+      const root = find(node.templateId);
+      grouped.set(root, [...(grouped.get(root) ?? []), node]);
+    }
+    const duplicateGroups = [...grouped.values()]
+      .filter((group) => group.length > 1)
+      .map((group) => {
+        const templateIds = new Set(group.map((node) => node.templateId));
+        const groupEdges = edges.filter(
+          (edge) => templateIds.has(edge.left) && templateIds.has(edge.right),
+        );
+        const stableRegistry = (node: (typeof group)[number]) =>
+          Boolean(
+            node.registrySourceId &&
+              (node.adapter !== "direct" || node.identityMode === "stable-source"),
+          );
+        const recommendation = [...group].sort(
+          (left, right) =>
+            Number(left.reviewStatus === "archived") - Number(right.reviewStatus === "archived") ||
+            Number(!stableRegistry(left)) - Number(!stableRegistry(right)) ||
+            Number(!left.registrySourceId) - Number(!right.registrySourceId) ||
+            Number(left.codeStatus !== "reviewed") - Number(right.codeStatus !== "reviewed") ||
+            right.metadataCompleteness - left.metadataCompleteness ||
+            left.importedAt.localeCompare(right.importedAt) ||
+            left.templateId.localeCompare(right.templateId),
+        )[0]!;
+        return {
+          groupId: sha256([...templateIds].sort().join("\n")).slice(0, 16),
+          templateIds: [...templateIds].sort(),
+          evidence: groupEdges,
+          recommendedCanonicalTemplateId: recommendation.templateId,
+          recommendationOnly: true as const,
+        };
+      })
+      .sort((left, right) => left.groupId.localeCompare(right.groupId));
+    return {
+      scope,
+      includeArchived,
+      libraryDirectory: this.root,
+      userTemplateCount: nodes.length,
+      legacyTemplateCount: nodes.filter((node) => node.legacy).length,
+      invalidTemplateCount: scan.invalid.length,
+      duplicateGroupCount: duplicateGroups.length,
+      invalid: scope === "duplicates" || scope === "legacy" ? [] : scan.invalid,
+      templates:
+        scope === "legacy"
+          ? nodes.filter((node) => node.legacy)
+          : scope === "integrity"
+            ? []
+            : nodes,
+      duplicateGroups:
+        scope === "legacy" || scope === "integrity" ? [] : duplicateGroups,
+    };
+  }
+
+  private async writeJournal(directory: string, value: unknown) {
+    await fs.mkdir(directory, { recursive: true });
+    const target = path.join(directory, "journal.json");
+    const temporary = path.join(directory, `.journal-${randomUUID()}.json`);
+    await fs.writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+    await fs.rename(temporary, target);
+  }
+
+  private async validateReconcile(input: ReconcileInput) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/u.test(input.reconcileId)) {
+      throw new Error("reconcileId must be a portable 1-100 character identifier");
+    }
+    if (!input.reason.trim()) throw new Error("reconcile requires a non-empty reason");
+    const duplicateIds = [...new Set(input.duplicateTemplateIds)];
+    if (duplicateIds.length === 0 || duplicateIds.length !== input.duplicateTemplateIds.length) {
+      throw new Error("duplicateTemplateIds must be a non-empty unique list");
+    }
+    if (duplicateIds.includes(input.canonicalTemplateId)) {
+      throw new Error("canonicalTemplateId cannot also be a duplicate");
+    }
+    const scan = await this.scanTemplates({ verifyFiles: true });
+    const byId = new Map(scan.valid.map((item) => [item.template.templateId, item]));
+    const ids = [input.canonicalTemplateId, ...duplicateIds];
+    for (const templateId of ids) {
+      const item = byId.get(templateId);
+      if (!item) throw new Error(`reconcile template is missing or invalid: ${templateId}`);
+      const expected = input.expectedState[templateId];
+      if (!expected) throw new Error(`expectedState is missing ${templateId}`);
+      if (
+        item.manifestSha256 !== expected.manifestSha256 ||
+        item.verifiedFileSetDigest !== expected.verifiedFileSetDigest ||
+        (item.template.reviewStatus ?? "approved") !== expected.reviewStatus
+      ) {
+        throw new Error(`stale reconcile state for ${templateId}`);
+      }
+    }
+    const audit = await this.auditTemplates({ scope: "duplicates", includeArchived: true });
+    const planned = new Set(ids);
+    const oneGroup = audit.duplicateGroups.some((group) =>
+      [...planned].every((templateId) => group.templateIds.includes(templateId)),
+    );
+    if (!oneGroup) {
+      throw new Error("reconcile templates are not connected by audit duplicate evidence");
+    }
+    return { scan, byId, duplicateIds };
+  }
+
+  async reconcileTemplates(input: ReconcileInput) {
+    const mode = input.mode ?? "dry-run";
+    if (mode === "rollback") return this.rollbackReconcile(input);
+    const validated = await this.validateReconcile(input);
+    const changes = validated.duplicateIds.map((templateId) => {
+      const item = validated.byId.get(templateId)!;
+      return {
+        templateId,
+        beforeReviewStatus: item.template.reviewStatus ?? "approved",
+        afterReviewStatus: "archived" as const,
+        retainedFiles:
+          Number(Boolean(item.template.preview)) +
+          item.template.code.length +
+          (item.template.references ?? []).length,
+      };
+    });
+    const plan = {
+      reconcileId: input.reconcileId,
+      mode,
+      strategy: input.strategy,
+      canonicalTemplateId: input.canonicalTemplateId,
+      duplicateTemplateIds: validated.duplicateIds,
+      changes,
+      filesRetained: changes.reduce((sum, item) => sum + item.retainedFiles, 0),
+      written: false,
+    };
+    if (mode === "dry-run") return plan;
+    return this.withWriteLock(`reconcile:${input.reconcileId}`, async () => {
+      const current = await this.validateReconcile(input);
+      const transactionDirectory = path.join(this.transactionsDirectory, input.reconcileId);
       try {
-        await fs.rename(temporary, manifest);
+        await fs.access(transactionDirectory);
+        throw new Error(`reconcile transaction already exists: ${input.reconcileId}`);
       } catch (error) {
-        await fs.rename(backup, manifest);
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      const now = new Date().toISOString();
+      const entries = await Promise.all(
+        current.duplicateIds.map(async (templateId) => {
+          const item = current.byId.get(templateId)!;
+          const beforeManifest = await fs.readFile(
+            path.join(item.directory, "template.json"),
+            "utf8",
+          );
+          const afterTemplate: UserTemplate = {
+            ...item.template,
+            reviewStatus: "archived",
+            archivedAt: now,
+            updatedAt: now,
+          };
+          const afterManifest = `${JSON.stringify(afterTemplate, null, 2)}\n`;
+          return {
+            templateId,
+            directory: item.directory,
+            beforeManifest,
+            beforeManifestSha256: sha256(beforeManifest),
+            afterManifest,
+            afterManifestSha256: sha256(afterManifest),
+          };
+        }),
+      );
+      const journal = {
+        schema: "figure-library.reconcile-transaction.v1",
+        reconcileId: input.reconcileId,
+        status: "prepared",
+        canonicalTemplateId: input.canonicalTemplateId,
+        duplicateTemplateIds: current.duplicateIds,
+        strategy: input.strategy,
+        reason: input.reason.trim(),
+        createdAt: now,
+        entries,
+      };
+      await this.writeJournal(transactionDirectory, journal);
+      const applied: typeof entries = [];
+      const ledgerDirectory = path.join(this.root, "migrations", "reconciliations");
+      const ledgerFile = path.join(ledgerDirectory, `${input.reconcileId}.json`);
+      let ledgerCreated = false;
+      try {
+        journal.status = "committing";
+        await this.writeJournal(transactionDirectory, journal);
+        for (const entry of entries) {
+          await this.replaceManifest(entry.directory, JSON.parse(entry.afterManifest) as UserTemplate);
+          applied.push(entry);
+        }
+        await fs.mkdir(ledgerDirectory, { recursive: true });
+        await fs.writeFile(
+          ledgerFile,
+          `${JSON.stringify(
+            {
+              schema: "figure-library.reconcile-ledger.v1",
+              reconcileId: input.reconcileId,
+              canonicalTemplateId: input.canonicalTemplateId,
+              aliases: current.duplicateIds.map((templateId) => ({
+                templateId,
+                canonicalTemplateId: input.canonicalTemplateId,
+              })),
+              reason: input.reason.trim(),
+              committedAt: new Date().toISOString(),
+              entries: entries.map(({ templateId, beforeManifestSha256, afterManifestSha256 }) => ({
+                templateId,
+                beforeManifestSha256,
+                afterManifestSha256,
+              })),
+            },
+            null,
+            2,
+          )}\n`,
+          { flag: "wx" },
+        );
+        ledgerCreated = true;
+        journal.status = "committed";
+        await this.writeJournal(transactionDirectory, journal);
+      } catch (error) {
+        let rollbackError: unknown;
+        for (const entry of [...applied].reverse()) {
+          try {
+            await this.replaceManifest(
+              entry.directory,
+              JSON.parse(entry.beforeManifest) as UserTemplate,
+            );
+          } catch (restoreError) {
+            rollbackError ??= restoreError;
+          }
+        }
+        if (ledgerCreated) {
+          try {
+            await fs.rm(ledgerFile);
+          } catch (removeError) {
+            rollbackError ??= removeError;
+          }
+        }
+        if (!rollbackError) {
+          journal.status = "rolled-back";
+          try {
+            await this.writeJournal(transactionDirectory, journal);
+          } catch (journalError) {
+            rollbackError = journalError;
+          }
+        }
+        if (rollbackError) {
+          throw new Error(
+            `reconcile failed and automatic recovery also failed: ${String(error)}; ${String(rollbackError)}`,
+          );
+        }
         throw error;
       }
-      await fs.rm(backup, { force: true });
-    } catch (error) {
-      await fs.rm(temporary, { force: true });
-      throw error;
+      return { ...plan, mode: "apply" as const, written: true };
+    });
+  }
+
+  private async rollbackReconcile(input: ReconcileInput) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/u.test(input.reconcileId)) {
+      throw new Error("reconcileId must be a portable 1-100 character identifier");
     }
-    return { template, directory: loaded.directory, existed: false };
+    if (!input.reason.trim()) throw new Error("rollback requires a non-empty reason");
+    return this.withWriteLock(`reconcile-rollback:${input.reconcileId}`, async () => {
+      const transactionDirectory = path.join(this.transactionsDirectory, input.reconcileId);
+      const journal = JSON.parse(
+        await fs.readFile(path.join(transactionDirectory, "journal.json"), "utf8"),
+      ) as {
+        status: string;
+        canonicalTemplateId: string;
+        duplicateTemplateIds: string[];
+        entries: Array<{
+          templateId: string;
+          directory: string;
+          beforeManifest: string;
+          beforeManifestSha256: string;
+          afterManifest: string;
+          afterManifestSha256: string;
+        }>;
+      };
+      if (journal.status !== "committed") {
+        throw new Error(`reconcile ${input.reconcileId} is not in committed state`);
+      }
+      if (
+        journal.canonicalTemplateId !== input.canonicalTemplateId ||
+        JSON.stringify([...journal.duplicateTemplateIds].sort()) !==
+          JSON.stringify([...new Set(input.duplicateTemplateIds)].sort())
+      ) {
+        throw new Error("rollback request does not match the committed reconcile transaction");
+      }
+      for (const entry of journal.entries) {
+        const current = await fs.readFile(path.join(entry.directory, "template.json"), "utf8");
+        if (sha256(current) !== entry.afterManifestSha256) {
+          throw new Error(`rollback would overwrite later changes to ${entry.templateId}`);
+        }
+      }
+      const ledgerDirectory = path.join(this.root, "migrations", "reconciliations");
+      const rollbackLedger = path.join(ledgerDirectory, `${input.reconcileId}.rollback.json`);
+      try {
+        await fs.access(rollbackLedger);
+        throw new Error(`reconcile rollback record already exists: ${input.reconcileId}`);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      journal.status = "rolling-back";
+      await this.writeJournal(transactionDirectory, journal);
+      const restored: typeof journal.entries = [];
+      let rollbackLedgerCreated = false;
+      try {
+        for (const entry of journal.entries) {
+          await this.replaceManifest(
+            entry.directory,
+            JSON.parse(entry.beforeManifest) as UserTemplate,
+          );
+          restored.push(entry);
+        }
+        await fs.mkdir(ledgerDirectory, { recursive: true });
+        await fs.writeFile(
+          rollbackLedger,
+          `${JSON.stringify(
+            {
+              schema: "figure-library.reconcile-rollback.v1",
+              reconcileId: input.reconcileId,
+              rolledBackAt: new Date().toISOString(),
+              reason: input.reason.trim(),
+            },
+            null,
+            2,
+          )}\n`,
+          { flag: "wx" },
+        );
+        rollbackLedgerCreated = true;
+        journal.status = "rolled-back";
+        await this.writeJournal(transactionDirectory, journal);
+      } catch (error) {
+        let recoveryError: unknown;
+        for (const entry of [...restored].reverse()) {
+          try {
+            await this.replaceManifest(
+              entry.directory,
+              JSON.parse(entry.afterManifest) as UserTemplate,
+            );
+          } catch (restoreError) {
+            recoveryError ??= restoreError;
+          }
+        }
+        if (rollbackLedgerCreated) {
+          try {
+            await fs.rm(rollbackLedger);
+          } catch (removeError) {
+            recoveryError ??= removeError;
+          }
+        }
+        if (!recoveryError) {
+          journal.status = "committed";
+          try {
+            await this.writeJournal(transactionDirectory, journal);
+          } catch (journalError) {
+            recoveryError = journalError;
+          }
+        }
+        if (recoveryError) {
+          throw new Error(
+            `reconcile rollback failed and restoring the committed state also failed: ${String(error)}; ${String(recoveryError)}`,
+          );
+        }
+        throw error;
+      }
+      return {
+        reconcileId: input.reconcileId,
+        mode: "rollback" as const,
+        canonicalTemplateId: input.canonicalTemplateId,
+        restoredTemplateIds: journal.entries.map((entry) => entry.templateId),
+        written: true,
+      };
+    });
   }
 
   async search(request: SearchRequest): Promise<TemplateCandidate[]> {

--- a/src/user-library.ts
+++ b/src/user-library.ts
@@ -596,7 +596,11 @@ export class UserTemplateLibrary {
     return incomplete.sort();
   }
 
-  private async withWriteLock<T>(operation: string, callback: () => Promise<T>) {
+  private async withWriteLock<T>(
+    operation: string,
+    callback: () => Promise<T>,
+    options: { allowIncompleteTransaction?: string } = {},
+  ) {
     await fs.mkdir(this.root, { recursive: true });
     try {
       await fs.mkdir(this.writeLockDirectory);
@@ -618,7 +622,9 @@ export class UserTemplateLibrary {
         `${JSON.stringify({ operation, pid: process.pid, createdAt: new Date().toISOString() }, null, 2)}\n`,
         { flag: "wx" },
       );
-      const incomplete = await this.incompleteTransactions();
+      const incomplete = (await this.incompleteTransactions()).filter(
+        (transactionId) => transactionId !== options.allowIncompleteTransaction,
+      );
       if (incomplete.length) {
         throw new Error(
           `incomplete user-library transaction requires recovery: ${incomplete.join(", ")}`,
@@ -1757,119 +1763,226 @@ export class UserTemplateLibrary {
       throw new Error("reconcileId must be a portable 1-100 character identifier");
     }
     if (!input.reason.trim()) throw new Error("rollback requires a non-empty reason");
-    return this.withWriteLock(`reconcile-rollback:${input.reconcileId}`, async () => {
-      const transactionDirectory = path.join(this.transactionsDirectory, input.reconcileId);
-      const journal = JSON.parse(
-        await fs.readFile(path.join(transactionDirectory, "journal.json"), "utf8"),
-      ) as {
-        status: string;
-        canonicalTemplateId: string;
-        duplicateTemplateIds: string[];
-        entries: Array<{
-          templateId: string;
-          directory: string;
-          beforeManifest: string;
-          beforeManifestSha256: string;
-          afterManifest: string;
-          afterManifestSha256: string;
-        }>;
-      };
-      if (journal.status !== "committed") {
-        throw new Error(`reconcile ${input.reconcileId} is not in committed state`);
-      }
-      if (
-        journal.canonicalTemplateId !== input.canonicalTemplateId ||
-        JSON.stringify([...journal.duplicateTemplateIds].sort()) !==
-          JSON.stringify([...new Set(input.duplicateTemplateIds)].sort())
-      ) {
-        throw new Error("rollback request does not match the committed reconcile transaction");
-      }
-      for (const entry of journal.entries) {
-        const current = await fs.readFile(path.join(entry.directory, "template.json"), "utf8");
-        if (sha256(current) !== entry.afterManifestSha256) {
-          throw new Error(`rollback would overwrite later changes to ${entry.templateId}`);
+    return this.withWriteLock(
+      `reconcile-rollback:${input.reconcileId}`,
+      async () => {
+        const transactionDirectory = path.join(this.transactionsDirectory, input.reconcileId);
+        const journal = JSON.parse(
+          await fs.readFile(path.join(transactionDirectory, "journal.json"), "utf8"),
+        ) as {
+          schema?: string;
+          reconcileId?: string;
+          status: string;
+          canonicalTemplateId: string;
+          duplicateTemplateIds: string[];
+          entries: Array<{
+            templateId: string;
+            directory: string;
+            beforeManifest: string;
+            beforeManifestSha256: string;
+            afterManifest: string;
+            afterManifestSha256: string;
+          }>;
+        };
+        if (
+          journal.schema !== "figure-library.reconcile-transaction.v1" ||
+          journal.reconcileId !== input.reconcileId ||
+          !Array.isArray(journal.entries)
+        ) {
+          throw new Error(`reconcile ${input.reconcileId} has an invalid recovery journal`);
         }
-      }
-      const ledgerDirectory = path.join(this.root, "migrations", "reconciliations");
-      const rollbackLedger = path.join(ledgerDirectory, `${input.reconcileId}.rollback.json`);
-      try {
-        await fs.access(rollbackLedger);
-        throw new Error(`reconcile rollback record already exists: ${input.reconcileId}`);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      }
-      journal.status = "rolling-back";
-      await this.writeJournal(transactionDirectory, journal);
-      const restored: typeof journal.entries = [];
-      let rollbackLedgerCreated = false;
-      try {
+        const recoverableStatuses = new Set(["prepared", "committing", "committed", "rolling-back"]);
+        if (!recoverableStatuses.has(journal.status)) {
+          throw new Error(`reconcile ${input.reconcileId} is not recoverable from ${journal.status}`);
+        }
+        const recoveredIncomplete = journal.status !== "committed";
+        if (
+          journal.canonicalTemplateId !== input.canonicalTemplateId ||
+          JSON.stringify([...journal.duplicateTemplateIds].sort()) !==
+            JSON.stringify([...new Set(input.duplicateTemplateIds)].sort())
+        ) {
+          throw new Error("rollback request does not match the reconcile transaction journal");
+        }
+
+        const journalEntryIds = journal.entries.map((entry) => entry.templateId);
+        if (
+          new Set(journalEntryIds).size !== journalEntryIds.length ||
+          JSON.stringify([...journalEntryIds].sort()) !==
+            JSON.stringify([...journal.duplicateTemplateIds].sort())
+        ) {
+          throw new Error(`reconcile ${input.reconcileId} has inconsistent journal entries`);
+        }
         for (const entry of journal.entries) {
-          await this.replaceManifest(
-            entry.directory,
-            JSON.parse(entry.beforeManifest) as UserTemplate,
-          );
-          restored.push(entry);
-        }
-        await fs.mkdir(ledgerDirectory, { recursive: true });
-        await fs.writeFile(
-          rollbackLedger,
-          `${JSON.stringify(
-            {
-              schema: "figure-library.reconcile-rollback.v1",
-              reconcileId: input.reconcileId,
-              rolledBackAt: new Date().toISOString(),
-              reason: input.reason.trim(),
-            },
-            null,
-            2,
-          )}\n`,
-          { flag: "wx" },
-        );
-        rollbackLedgerCreated = true;
-        journal.status = "rolled-back";
-        await this.writeJournal(transactionDirectory, journal);
-      } catch (error) {
-        let recoveryError: unknown;
-        for (const entry of [...restored].reverse()) {
+          const expectedDirectory = path.join(this.templatesDirectory, entry.templateId);
+          if (path.resolve(entry.directory) !== path.resolve(expectedDirectory)) {
+            throw new Error(`reconcile journal has an unsafe template directory: ${entry.templateId}`);
+          }
+          if (
+            sha256(entry.beforeManifest) !== entry.beforeManifestSha256 ||
+            sha256(entry.afterManifest) !== entry.afterManifestSha256
+          ) {
+            throw new Error(`reconcile journal manifest hash mismatch: ${entry.templateId}`);
+          }
+          let before: unknown;
+          let after: unknown;
           try {
+            before = JSON.parse(entry.beforeManifest) as unknown;
+            after = JSON.parse(entry.afterManifest) as unknown;
+          } catch {
+            throw new Error(`reconcile journal contains invalid manifest JSON: ${entry.templateId}`);
+          }
+          if (
+            !isUserTemplate(before) ||
+            !isUserTemplate(after) ||
+            before.templateId !== entry.templateId ||
+            after.templateId !== entry.templateId
+          ) {
+            throw new Error(`reconcile journal contains invalid template manifests: ${entry.templateId}`);
+          }
+        }
+
+        const currentHashes = new Map<string, string>();
+        for (const entry of journal.entries) {
+          const directoryStat = await fs.lstat(entry.directory);
+          const manifestPath = path.join(entry.directory, "template.json");
+          const manifestStat = await fs.lstat(manifestPath);
+          if (
+            directoryStat.isSymbolicLink() ||
+            !directoryStat.isDirectory() ||
+            manifestStat.isSymbolicLink() ||
+            !manifestStat.isFile()
+          ) {
+            throw new Error(`rollback target is not a regular template: ${entry.templateId}`);
+          }
+          const current = await fs.readFile(manifestPath, "utf8");
+          const currentHash = sha256(current);
+          const allowed = recoveredIncomplete
+            ? [entry.beforeManifestSha256, entry.afterManifestSha256]
+            : [entry.afterManifestSha256];
+          if (!allowed.includes(currentHash)) {
+            throw new Error(`rollback would overwrite later changes to ${entry.templateId}`);
+          }
+          currentHashes.set(entry.templateId, currentHash);
+        }
+
+        const ledgerDirectory = path.join(this.root, "migrations", "reconciliations");
+        const applyLedger = path.join(ledgerDirectory, `${input.reconcileId}.json`);
+        const rollbackLedger = path.join(ledgerDirectory, `${input.reconcileId}.rollback.json`);
+        let incompleteApplyLedger: string | undefined;
+        if (recoveredIncomplete) {
+          try {
+            incompleteApplyLedger = await fs.readFile(applyLedger, "utf8");
+            const parsed = JSON.parse(incompleteApplyLedger) as {
+              schema?: string;
+              reconcileId?: string;
+            };
+            if (
+              parsed.schema !== "figure-library.reconcile-ledger.v1" ||
+              parsed.reconcileId !== input.reconcileId
+            ) {
+              throw new Error(`incomplete reconcile has an unrelated ledger: ${input.reconcileId}`);
+            }
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+            incompleteApplyLedger = undefined;
+          }
+        }
+        try {
+          await fs.access(rollbackLedger);
+          throw new Error(`reconcile rollback record already exists: ${input.reconcileId}`);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
+
+        journal.status = "rolling-back";
+        await this.writeJournal(transactionDirectory, journal);
+        const restored: typeof journal.entries = [];
+        let applyLedgerRemoved = false;
+        let rollbackLedgerCreated = false;
+        try {
+          for (const entry of journal.entries) {
+            if (currentHashes.get(entry.templateId) === entry.beforeManifestSha256) continue;
             await this.replaceManifest(
               entry.directory,
-              JSON.parse(entry.afterManifest) as UserTemplate,
+              JSON.parse(entry.beforeManifest) as UserTemplate,
             );
-          } catch (restoreError) {
-            recoveryError ??= restoreError;
+            restored.push(entry);
           }
-        }
-        if (rollbackLedgerCreated) {
-          try {
-            await fs.rm(rollbackLedger);
-          } catch (removeError) {
-            recoveryError ??= removeError;
+          if (incompleteApplyLedger !== undefined) {
+            await fs.rm(applyLedger);
+            applyLedgerRemoved = true;
           }
-        }
-        if (!recoveryError) {
-          journal.status = "committed";
-          try {
-            await this.writeJournal(transactionDirectory, journal);
-          } catch (journalError) {
-            recoveryError = journalError;
-          }
-        }
-        if (recoveryError) {
-          throw new Error(
-            `reconcile rollback failed and restoring the committed state also failed: ${String(error)}; ${String(recoveryError)}`,
+          await fs.mkdir(ledgerDirectory, { recursive: true });
+          await fs.writeFile(
+            rollbackLedger,
+            `${JSON.stringify(
+              {
+                schema: "figure-library.reconcile-rollback.v1",
+                reconcileId: input.reconcileId,
+                recoveredIncomplete,
+                rolledBackAt: new Date().toISOString(),
+                reason: input.reason.trim(),
+              },
+              null,
+              2,
+            )}\n`,
+            { flag: "wx" },
           );
+          rollbackLedgerCreated = true;
+          journal.status = "rolled-back";
+          await this.writeJournal(transactionDirectory, journal);
+        } catch (error) {
+          let recoveryError: unknown;
+          for (const entry of [...restored].reverse()) {
+            try {
+              await this.replaceManifest(
+                entry.directory,
+                JSON.parse(entry.afterManifest) as UserTemplate,
+              );
+            } catch (restoreError) {
+              recoveryError ??= restoreError;
+            }
+          }
+          if (applyLedgerRemoved && incompleteApplyLedger !== undefined) {
+            try {
+              await fs.writeFile(applyLedger, incompleteApplyLedger, { flag: "wx" });
+            } catch (ledgerRestoreError) {
+              recoveryError ??= ledgerRestoreError;
+            }
+          }
+          if (rollbackLedgerCreated) {
+            try {
+              await fs.rm(rollbackLedger);
+            } catch (removeError) {
+              recoveryError ??= removeError;
+            }
+          }
+          if (!recoveryError) {
+            journal.status = recoveredIncomplete ? "committing" : "committed";
+            try {
+              await this.writeJournal(transactionDirectory, journal);
+            } catch (journalError) {
+              recoveryError = journalError;
+            }
+          }
+          if (recoveryError) {
+            throw new Error(
+              `reconcile rollback failed and restoring the prior state also failed: ${String(error)}; ${String(recoveryError)}`,
+            );
+          }
+          throw error;
         }
-        throw error;
-      }
-      return {
-        reconcileId: input.reconcileId,
-        mode: "rollback" as const,
-        canonicalTemplateId: input.canonicalTemplateId,
-        restoredTemplateIds: journal.entries.map((entry) => entry.templateId),
-        written: true,
-      };
-    });
+        return {
+          reconcileId: input.reconcileId,
+          mode: "rollback" as const,
+          canonicalTemplateId: input.canonicalTemplateId,
+          restoredTemplateIds: journal.entries.map((entry) => entry.templateId),
+          recoveredIncomplete,
+          written: true,
+        };
+      },
+      { allowIncompleteTransaction: input.reconcileId },
+    );
   }
 
   async search(request: SearchRequest): Promise<TemplateCandidate[]> {

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -33,6 +33,7 @@ test("FigureYa source retrieves common plot families", async () => {
       `${query} ranked the wrong family first: ${results.map((item) => item.templateId).join(", ")}`,
     );
     assert.ok(results.every((result) => result.sourceId === "figureya"));
+    assert.ok(results.every((result) => result.management.canArchive === false));
   }
 });
 
@@ -197,7 +198,9 @@ test("user figures and code import, search, and materialize without executing", 
       codePaths: [codePath],
     });
     assert.equal(imported.existed, false);
-    assert.match(imported.template.templateId, /^user-custom-single-cell-ridge-plot-/u);
+    assert.match(imported.template.templateId, /^user-direct-[a-f0-9]{16}$/u);
+    assert.equal(imported.template.registry?.adapter, "direct");
+    assert.equal(imported.template.registry?.identityMode, "content-addressed");
     assert.equal(imported.template.assetKind, "plot_template");
     assert.equal(imported.template.language, "R");
 
@@ -220,6 +223,8 @@ test("user figures and code import, search, and materialize without executing", 
 
     const results = await library.search({ query: "single cell ridge plot", limit: 3 });
     assert.equal(results[0]?.templateId, imported.template.templateId);
+    assert.equal(results[0]?.management.adapter, "direct");
+    assert.equal(results[0]?.management.canArchive, true);
     assert.match(results[0]?.previewDataUrl ?? "", /^data:image\/png;base64,/u);
     const preview = await library.preview(imported.template.templateId);
     assert.equal(preview?.mimeType, "image/png");

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -6,7 +6,8 @@ import path from "node:path";
 import test from "node:test";
 import { strToU8, zipSync } from "fflate";
 import { stringify } from "yaml";
-import { UserTemplateLibrary } from "../src/user-library.ts";
+import { prepareDirectImport } from "../src/importers.ts";
+import { managementReference, UserTemplateLibrary } from "../src/user-library.ts";
 
 const PNG = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
 
@@ -329,6 +330,403 @@ test("Gallery sync imports only approved entries and supports filters, diff, ups
     );
   } finally {
     await fs.chmod(root, 0o755).catch(() => undefined);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("direct imports plan stable updates, require duplicate decisions, replay safely, and archive by templateId", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "figure-library-direct-plan-test-"));
+  try {
+    const source = path.join(root, "source");
+    await fs.mkdir(source);
+    const previewPath = path.join(source, "preview.png");
+    const codePath = path.join(source, "plot.R");
+    await fs.writeFile(previewPath, PNG);
+    await fs.writeFile(codePath, "library(ggplot2)\n# stable direct source\n");
+    const library = new UserTemplateLibrary(path.join(root, "library"));
+    const direct = {
+      title: "Stable direct plot",
+      description: "First reviewed description",
+      sourceKey: "manual:stable-direct-plot",
+      imagePath: previewPath,
+      codePaths: [codePath],
+    };
+    await assert.rejects(
+      library.planDirectImport({ ...direct, sourceKey: "/host/private/plot" }),
+      /portable logical identifier|lowercase ASCII/u,
+    );
+    await assert.rejects(
+      library.planDirectImport({ ...direct, sourceKey: "https://example.test/plot?token=secret" }),
+      /portable logical identifier|lowercase ASCII/u,
+    );
+
+    const planned = await library.planDirectImport(direct);
+    assert.equal(planned.action, "create");
+    assert.equal(planned.written, false);
+    assert.equal((await library.list()).length, 0);
+    assert.match(planned.proposedTemplateId, /^user-direct-[a-f0-9]{16}$/u);
+    assert.equal(planned.proposedTemplateId.includes("stable-direct-plot"), false);
+
+    const applied = await library.applyDirectImport({
+      ...direct,
+      planDigest: planned.planDigest,
+      expectedAction: planned.action,
+      expectedTemplateId: planned.proposedTemplateId,
+      operationId: "direct-create-1",
+    });
+    assert.equal(applied.action, "create");
+    assert.equal(applied.replayed, false);
+    assert.equal(applied.template.registry?.sourceId, "manual:stable-direct-plot");
+
+    const replayed = await library.applyDirectImport({
+      ...direct,
+      planDigest: planned.planDigest,
+      expectedAction: "create",
+      expectedTemplateId: planned.proposedTemplateId,
+      operationId: "direct-create-1",
+    });
+    assert.equal(replayed.action, "unchanged");
+    assert.equal(replayed.replayed, true);
+
+    const updatedInput = {
+      ...direct,
+      title: "Stable direct plot with confirmed title",
+      description: "Updated reviewed description",
+    };
+    const updatePlan = await library.planDirectImport(updatedInput);
+    assert.equal(updatePlan.action, "update");
+    assert.equal(updatePlan.proposedTemplateId, applied.template.templateId);
+    assert.ok(updatePlan.changes.some((change) => change.field === "title"));
+    const updated = await library.applyDirectImport({
+      ...updatedInput,
+      planDigest: updatePlan.planDigest,
+      expectedAction: updatePlan.action,
+      expectedTemplateId: updatePlan.proposedTemplateId,
+      operationId: "direct-update-1",
+    });
+    assert.equal(updated.action, "update");
+    assert.equal(updated.template.templateId, applied.template.templateId);
+
+    const duplicateInput = { ...updatedInput, sourceKey: "manual:separate-source" };
+    const duplicatePlan = await library.planDirectImport(duplicateInput);
+    assert.equal(duplicatePlan.action, "duplicate_candidate");
+    await assert.rejects(
+      library.applyDirectImport({
+        ...duplicateInput,
+        planDigest: duplicatePlan.planDigest,
+        expectedAction: duplicatePlan.action,
+        expectedTemplateId: duplicatePlan.proposedTemplateId,
+        operationId: "direct-duplicate-rejected",
+      }),
+      /explicit reuse or create_separate/u,
+    );
+    const reused = await library.applyDirectImport({
+      ...duplicateInput,
+      planDigest: duplicatePlan.planDigest,
+      expectedAction: duplicatePlan.action,
+      expectedTemplateId: duplicatePlan.proposedTemplateId,
+      operationId: "direct-duplicate-reuse",
+      duplicateResolution: {
+        action: "reuse",
+        templateId: updated.template.templateId,
+        reason: "The files are identical and this source should reuse the canonical template.",
+      },
+    });
+    assert.equal(reused.action, "reused");
+    assert.equal((await library.list()).length, 1);
+    assert.equal((await library.planDirectImport(duplicateInput)).action, "unchanged");
+
+    const renamedAlias = {
+      ...duplicateInput,
+      title: "A different label for the reused source",
+      description: "Alias metadata does not overwrite the canonical template.",
+    };
+    const renamedAliasPlan = await library.planDirectImport(renamedAlias);
+    assert.equal(renamedAliasPlan.action, "unchanged");
+    assert.equal(renamedAliasPlan.proposedTemplateId, updated.template.templateId);
+    assert.equal((await library.get(updated.template.templateId))?.template.title, updatedInput.title);
+
+    await fs.writeFile(codePath, "library(ggplot2)\n# intentionally diverged alias source\n");
+    const divergedAliasPlan = await library.planDirectImport(renamedAlias);
+    assert.equal(divergedAliasPlan.action, "source_conflict");
+    assert.notEqual(divergedAliasPlan.proposedTemplateId, updated.template.templateId);
+    const divergedAlias = await library.applyDirectImport({
+      ...renamedAlias,
+      planDigest: divergedAliasPlan.planDigest,
+      expectedAction: divergedAliasPlan.action,
+      expectedTemplateId: divergedAliasPlan.proposedTemplateId,
+      operationId: "direct-alias-breakout-1",
+      sourceConflictResolution: {
+        action: "replace_source",
+        reason: "This reused source has intentionally diverged and must not overwrite its canonical.",
+      },
+    });
+    assert.equal(divergedAlias.action, "create");
+    assert.equal(divergedAlias.template.registry?.sourceId, "manual:separate-source");
+    assert.equal((await library.get(updated.template.templateId))?.template.title, updatedInput.title);
+    assert.equal((await library.list()).length, 2);
+    assert.equal((await library.planDirectImport(renamedAlias)).action, "unchanged");
+
+    const archived = await library.archiveTemplate({ templateId: updated.template.templateId });
+    assert.equal(archived.changed, true);
+    assert.equal(archived.alreadyArchived, false);
+    assert.equal(archived.template.reviewStatus, "archived");
+    assert.ok(await fs.stat(path.join(archived.directory, "code", "plot.R")));
+    const repeatedArchive = await library.archiveTemplate({
+      registrySourceId: "manual:stable-direct-plot",
+      adapter: "direct",
+    });
+    assert.equal(repeatedArchive.changed, false);
+    assert.equal(repeatedArchive.alreadyArchived, true);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an exact v0.2 legacy direct template remains idempotent without a silent migration", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "figure-library-legacy-repeat-test-"));
+  try {
+    const source = path.join(root, "source");
+    await fs.mkdir(source);
+    const codePath = path.join(source, "legacy.R");
+    await fs.writeFile(codePath, "# exact legacy direct template\n");
+    const input = {
+      title: "Legacy exact template",
+      description: "Preserve the v0.2 directory and manifest without writing on a repeat.",
+      codePaths: [codePath],
+    };
+    const prepared = await prepareDirectImport(input);
+    assert.ok(prepared.legacyTemplateId);
+    const library = new UserTemplateLibrary(path.join(root, "library"));
+    const imported = await library.importTemplate(input);
+    const legacyDirectory = path.join(library.templatesDirectory, prepared.legacyTemplateId!);
+    const manifest = imported.template;
+    delete manifest.registry;
+    manifest.templateId = prepared.legacyTemplateId!;
+    await fs.rename(imported.directory, legacyDirectory);
+    await fs.writeFile(
+      path.join(legacyDirectory, "template.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+
+    const repeated = await library.importTemplate(input);
+    assert.equal(repeated.action, "unchanged");
+    assert.equal(repeated.template.templateId, prepared.legacyTemplateId);
+    assert.equal(repeated.template.registry, undefined);
+    assert.equal((await library.list()).length, 1);
+
+    await library.archiveTemplate({ templateId: prepared.legacyTemplateId });
+    const separatePlan = await library.planDirectImport(input);
+    assert.equal(separatePlan.action, "duplicate_candidate");
+    assert.notEqual(separatePlan.proposedTemplateId, prepared.legacyTemplateId);
+    const separate = await library.applyDirectImport({
+      ...input,
+      planDigest: separatePlan.planDigest,
+      expectedAction: separatePlan.action,
+      expectedTemplateId: separatePlan.proposedTemplateId,
+      operationId: "legacy-create-separate-1",
+      duplicateResolution: {
+        action: "create_separate",
+        reason: "Keep the archived legacy record and create a separately managed current record.",
+      },
+    });
+    assert.equal(separate.action, "create");
+    assert.equal((await library.get(prepared.legacyTemplateId!))?.template.reviewStatus, "archived");
+    assert.equal((await library.list()).length, 2);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("title-only similarity is advisory and stored fingerprint drift is invalid", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "figure-library-audit-boundary-test-"));
+  try {
+    const firstCode = path.join(root, "first.R");
+    const secondCode = path.join(root, "second.R");
+    await fs.writeFile(firstCode, "# first unrelated implementation\n");
+    await fs.writeFile(secondCode, "# second unrelated implementation\n");
+    const library = new UserTemplateLibrary(path.join(root, "library"));
+    const first = await library.importTemplate({
+      title: "Shared display title",
+      sourceKey: "manual:title-only-a",
+      codePaths: [firstCode],
+    });
+    await library.importTemplate({
+      title: "Shared display title",
+      sourceKey: "manual:title-only-b",
+      codePaths: [secondCode],
+    });
+    const audit = await library.auditTemplates({ scope: "duplicates", includeArchived: true });
+    assert.equal(audit.duplicateGroupCount, 0);
+    assert.equal(managementReference(first.template).canUpdate, true);
+
+    const contentCode = path.join(root, "content-addressed.R");
+    await fs.writeFile(contentCode, "# content-addressed implementation\n");
+    const contentAddressed = await library.importTemplate({
+      title: "Content-addressed direct source",
+      codePaths: [contentCode],
+    });
+    assert.equal(contentAddressed.template.registry?.identityMode, "content-addressed");
+    assert.equal(managementReference(contentAddressed.template).canUpdate, true);
+
+    const manifestPath = path.join(first.directory, "template.json");
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+    manifest.registry.fingerprints.fullAssetSha256 = "0".repeat(64);
+    await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    const integrity = await library.auditTemplates({ scope: "integrity", includeArchived: true });
+    assert.equal(integrity.invalidTemplateCount, 1);
+    assert.match(integrity.invalid[0]!.error, /component fingerprints/u);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("writers preserve an existing lock and stop on an incomplete transaction", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "figure-library-write-guard-test-"));
+  try {
+    const codePath = path.join(root, "plot.R");
+    await fs.writeFile(codePath, "# writer guard\n");
+    const library = new UserTemplateLibrary(path.join(root, "library"));
+    await fs.mkdir(library.writeLockDirectory, { recursive: true });
+    await fs.writeFile(
+      path.join(library.writeLockDirectory, "owner.json"),
+      JSON.stringify({ operation: "other-writer", createdAt: "2026-08-04T00:00:00Z" }),
+    );
+    await assert.rejects(
+      library.importTemplate({ title: "Blocked by lock", codePaths: [codePath] }),
+      /write-locked/u,
+    );
+    assert.ok(await fs.stat(library.writeLockDirectory), "existing writer lock was deleted");
+    await fs.rm(library.writeLockDirectory, { recursive: true });
+
+    const transaction = path.join(library.transactionsDirectory, "interrupted-test");
+    await fs.mkdir(transaction, { recursive: true });
+    await fs.writeFile(
+      path.join(transaction, "journal.json"),
+      JSON.stringify({ status: "committing" }),
+    );
+    await assert.rejects(
+      library.importTemplate({ title: "Blocked by transaction", codePaths: [codePath] }),
+      /incomplete user-library transaction/u,
+    );
+    await assert.rejects(fs.stat(library.writeLockDirectory), /ENOENT/u);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("audit connects partial legacy duplicates and reconcile archives and rolls them back", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "figure-library-reconcile-test-"));
+  try {
+    const library = new UserTemplateLibrary(path.join(root, "library"));
+    const previewPath = path.join(root, "preview.png");
+    await fs.writeFile(previewPath, PNG);
+    const variants = [
+      { title: "UMAP density English", sourceKey: "legacy:a", code: "# code-one\n", readme: "notes-one\n" },
+      { title: "UMAP 密度模板", sourceKey: "legacy:b", code: "# code-two\n", readme: "notes-two\n" },
+      { title: "UMAP 密度模板", sourceKey: "legacy:c", code: "# code-one\n", readme: "notes-two\n" },
+    ];
+    const imported = [];
+    for (const [index, variant] of variants.entries()) {
+      const directory = path.join(root, `source-${index}`);
+      await fs.mkdir(directory);
+      const codePath = path.join(directory, "plot.R");
+      const readmePath = path.join(directory, "README.md");
+      await fs.writeFile(codePath, variant.code);
+      await fs.writeFile(readmePath, variant.readme);
+      const result = await library.importTemplate({
+        title: variant.title,
+        sourceKey: variant.sourceKey,
+        imagePath: previewPath,
+        codePaths: [codePath, readmePath],
+      });
+      const manifestPath = path.join(result.directory, "template.json");
+      const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+      delete manifest.registry;
+      await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+      imported.push(result);
+    }
+    const invalidDirectory = path.join(library.templatesDirectory, "invalid-template");
+    await fs.mkdir(invalidDirectory);
+    await fs.writeFile(path.join(invalidDirectory, "template.json"), "{not-json\n");
+
+    const audit = await library.auditTemplates({ scope: "all", includeArchived: true });
+    assert.equal(audit.legacyTemplateCount, 3);
+    assert.equal(audit.invalidTemplateCount, 1);
+    assert.equal(audit.duplicateGroupCount, 1);
+    const group = audit.duplicateGroups[0]!;
+    assert.equal(group.templateIds.length, 3);
+    assert.ok(group.evidence.every((edge) => edge.matchKinds.includes("same_preview")));
+    assert.ok(group.evidence.some((edge) => edge.matchKinds.includes("same_executable_code")));
+    assert.ok(group.evidence.some((edge) => edge.matchKinds.includes("same_metadata")));
+
+    const canonicalTemplateId = imported[0]!.template.templateId;
+    const duplicateTemplateIds = imported.slice(1).map((item) => item.template.templateId);
+    const expectedState = Object.fromEntries(
+      audit.templates
+        .filter((item) => [canonicalTemplateId, ...duplicateTemplateIds].includes(item.templateId))
+        .map((item) => [
+          item.templateId,
+          {
+            manifestSha256: item.manifestSha256,
+            verifiedFileSetDigest: item.verifiedFileSetDigest,
+            reviewStatus: item.reviewStatus,
+          },
+        ]),
+    );
+    const reconcile = {
+      reconcileId: "umap-legacy-test-1",
+      canonicalTemplateId,
+      duplicateTemplateIds,
+      strategy: "archive_duplicates" as const,
+      expectedState,
+      reason: "Synthetic legacy entries share component evidence and were reviewed for this test.",
+    };
+    const dryRun = await library.reconcileTemplates({ ...reconcile, mode: "dry-run" });
+    assert.equal(dryRun.written, false);
+    assert.ok("filesRetained" in dryRun);
+    assert.equal(dryRun.filesRetained, 6);
+    assert.equal((await library.get(duplicateTemplateIds[0]!))?.template.reviewStatus, "approved");
+
+    const applied = await library.reconcileTemplates({ ...reconcile, mode: "apply" });
+    assert.equal(applied.written, true);
+    for (const templateId of duplicateTemplateIds) {
+      const item = await library.get(templateId);
+      assert.equal(item?.template.reviewStatus, "archived");
+      assert.ok(await fs.stat(path.join(item!.directory, "preview.png")));
+    }
+    assert.notEqual((await library.get(canonicalTemplateId))?.template.reviewStatus, "archived");
+
+    const rolledBack = await library.reconcileTemplates({ ...reconcile, mode: "rollback" });
+    assert.equal(rolledBack.written, true);
+    for (const templateId of duplicateTemplateIds) {
+      assert.equal((await library.get(templateId))?.template.reviewStatus, "approved");
+    }
+    assert.ok(
+      await fs.stat(
+        path.join(library.root, "migrations", "reconciliations", "umap-legacy-test-1.rollback.json"),
+      ),
+    );
+
+    const failedReconcile = { ...reconcile, reconcileId: "umap-ledger-conflict-test" };
+    const ledgerDirectory = path.join(library.root, "migrations", "reconciliations");
+    await fs.mkdir(ledgerDirectory, { recursive: true });
+    await fs.writeFile(path.join(ledgerDirectory, `${failedReconcile.reconcileId}.json`), "reserved\n");
+    await assert.rejects(
+      library.reconcileTemplates({ ...failedReconcile, mode: "apply" }),
+      /EEXIST|file already exists/u,
+    );
+    for (const templateId of duplicateTemplateIds) {
+      assert.equal((await library.get(templateId))?.template.reviewStatus, "approved");
+    }
+    const failedJournal = JSON.parse(
+      await fs.readFile(
+        path.join(library.transactionsDirectory, failedReconcile.reconcileId, "journal.json"),
+        "utf8",
+      ),
+    );
+    assert.equal(failedJournal.status, "rolled-back");
+  } finally {
     await fs.rm(root, { recursive: true, force: true });
   }
 });

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -708,6 +708,37 @@ test("audit connects partial legacy duplicates and reconcile archives and rolls 
       ),
     );
 
+    const interruptedReconcile = { ...reconcile, reconcileId: "umap-interrupted-test" };
+    await library.reconcileTemplates({ ...interruptedReconcile, mode: "apply" });
+    const interruptedJournalPath = path.join(
+      library.transactionsDirectory,
+      interruptedReconcile.reconcileId,
+      "journal.json",
+    );
+    const interruptedJournal = JSON.parse(await fs.readFile(interruptedJournalPath, "utf8"));
+    interruptedJournal.status = "committing";
+    await fs.writeFile(interruptedJournalPath, `${JSON.stringify(interruptedJournal, null, 2)}\n`);
+    const recovered = await library.reconcileTemplates({
+      ...interruptedReconcile,
+      mode: "rollback",
+      reason: "Recover a simulated interruption after all manifests and the apply ledger were written.",
+    });
+    assert.equal("recoveredIncomplete" in recovered && recovered.recoveredIncomplete, true);
+    for (const templateId of duplicateTemplateIds) {
+      assert.equal((await library.get(templateId))?.template.reviewStatus, "approved");
+    }
+    await assert.rejects(
+      fs.stat(
+        path.join(
+          library.root,
+          "migrations",
+          "reconciliations",
+          `${interruptedReconcile.reconcileId}.json`,
+        ),
+      ),
+      /ENOENT/u,
+    );
+
     const failedReconcile = { ...reconcile, reconcileId: "umap-ledger-conflict-test" };
     const ledgerDirectory = path.join(library.root, "migrations", "reconciliations");
     await fs.mkdir(ledgerDirectory, { recursive: true });


### PR DESCRIPTION
## Summary

- add stable direct-import identity with optional `sourceKey`, component fingerprints, and a non-destructive `plan -> confirmed apply` workflow
- expose management references and allow logical archive by `templateId`, legacy `galleryId`, or adapter-scoped Registry source
- add raw integrity scanning, legacy/duplicate audit, deterministic canonical recommendations, and guarded reconcile/rollback transactions
- show title-first candidates plus copyable template IDs in the MCP App, update the Agent Skill/README, and prepare version 0.3.0

## Why this is needed

v0.2.0 completed stable Gallery and Figure Transfer Package imports, but direct imports still had metadata-coupled IDs and no Registry continuity. Search exposed a template ID while archive accepted only a Gallery ID, invalid template directories were silently omitted from normal listing, and there was no safe workflow for reviewing or reconciling legacy duplicates.

A read-only audit of a real legacy User Library found three UMAP entries in one evidence graph: all share the preview, two share executable code, and two share metadata/title evidence. This PR uses synthetic fixtures for that relationship; it does not include or migrate the real assets.

## Safety and compatibility

- `figure_library_import` direct-write behavior remains available for v0.2 clients; new Agent flows use `figure_library_plan_import` and `figure_library_apply_import`
- legacy Registry-less templates remain readable/materializable and exact legacy retries remain idempotent
- new Registry fields are optional under the existing `figure-library.template.v1` schema
- duplicate evidence never auto-merges; title-only similarity cannot form a duplicate group
- archive/reconcile retain every template directory and file
- all writers share a lock; reconcile uses manifest/file preconditions, a journal, failure recovery, and rollback protection
- FigureYa IDs/materialization and Gallery authority are unchanged

## Validation

Environment: Node `v22.23.2`, npm `9.2.0`.

- `npm run check` — passed (14 Node tests plus full MCP stdio smoke)
- `npm run package:npm` — passed; release whitelist inspected
- `npm run package:wisp` — passed; release whitelist and generated SHA-256 checked
- read-only real-library audit — 3 valid, 3 legacy, 0 invalid, 1 duplicate group, with the expected UMAP component evidence

No R or imported plotting code was executed. No real User Library migration or write was performed. No release was published, and generated `release/` artifacts are not committed.
