### PR TITLE
feat: 收紧公开模块发布边界并发布 0.6.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "figure-library",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Search Local Published, FigureYa, bundled Open Figure Modules, frozen explicit-only Community, and explicitly trusted dynamic Providers; materialize exact immutable figure references without executing module code.",
   "author": {
     "name": "xuzhougeng and jarxunlai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "figure-library",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Search Local Published, FigureYa, bundled Open Figure Modules, frozen explicit-only Community, and explicitly trusted dynamic Providers; materialize exact immutable figure references without executing module code.",
   "author": {
     "name": "xuzhougeng and jarxunlai",

--- a/.wisp-plugin/plugin.json
+++ b/.wisp-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schema": "wisp.plugin.v1",
   "id": "figure-library",
   "display_name": "Scientific Figure Library",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Local-first scientific figure library: import, review, publish, search, and materialize exact templates; includes the openly collaborative Open Figure Modules snapshot and frozen explicit-only Community compatibility.",
   "author": "xuzhougeng and jarxunlai",
   "license": "MIT (SFL and Community code); Apache-2.0 (figure-style and DOMPurify); see bundled third-party/Skill notices; CC BY 4.0 (Community synthetic content); CC BY-NC-SA 4.0 (FigureYa assets)",

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -822,9 +822,9 @@ npm run package:plugins
 
 This writes three artifacts into `release/`:
 
-- `scientific-figure-library-wisp-0.6.3.zip` — install from Wisp **Settings → Plugins**
-- `scientific-figure-library-codex-0.6.3.zip` — Codex plugin with `.codex-plugin/plugin.json`, `.codex-plugin/mcp.json`, and `skills/figure-library`
-- `scientific-figure-library-claude-0.6.3.zip` — Claude Code plugin with `.claude-plugin/plugin.json`, `.claude-plugin/mcp.json`, and auto-discovered `skills/`
+- `scientific-figure-library-wisp-0.6.4.zip` — install from Wisp **Settings → Plugins**
+- `scientific-figure-library-codex-0.6.4.zip` — Codex plugin with `.codex-plugin/plugin.json`, `.codex-plugin/mcp.json`, and `skills/figure-library`
+- `scientific-figure-library-claude-0.6.4.zip` — Claude Code plugin with `.claude-plugin/plugin.json`, `.claude-plugin/mcp.json`, and auto-discovered `skills/`
 
 Each package uses its Host's plugin-root contract. Codex resolves `cwd: "."`
 from the installed plugin root, Claude expands `${CLAUDE_PLUGIN_ROOT}`, and Wisp
@@ -846,7 +846,7 @@ Build a standalone npm package:
 
 ```bash
 npm run package:npm
-npm install --global ./release/scientific-figure-library-0.6.3.tgz
+npm install --global ./release/scientific-figure-library-0.6.4.tgz
 ```
 
 Use `scientific-figure-library` as the MCP command after installation.
@@ -882,7 +882,7 @@ npm run package:source-pack -- \
 
 The helper verifies selected ZIP identities and caps a transport pack at 200
 MiB. Extract the resulting
-`release/figure-library-source-pack-volcano-0.6.3.zip` before use.
+`release/figure-library-source-pack-volcano-0.6.4.zip` before use.
 
 ## Catalog development
 
@@ -921,7 +921,7 @@ and exact inventory before atomically replacing `assets/community`. The source
 checkout and target must be separate directory trees. Packaging has an
 additional final-release gate that requires the three reviewed 1.0.0 seed
 releases; the empty bootstrap snapshot is valid for development tests but
-cannot be packaged as the 0.6.3 release.
+cannot be packaged as the 0.6.4 release.
 
 ## Markdown descriptions and bundled Skills
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -593,6 +593,18 @@ must display and explicitly confirm both the old and new key fingerprints.
 
 ## Sanitized public submission export
 
+### Runtime closure for new plot templates
+
+New or updated Local Published plot templates may declare
+`runtime: figure-library.runtime-closure.v1`. The closure binds the selected
+canonical implementation, each required runtime input, its Local Published
+asset path, the path used by the code, and the generated PNG output. Publish
+planning validates the closure against the immutable revision inventory; it
+never reads a Gallery, inbox, project directory, or user home as an implicit
+fallback. Older Releases without this optional field remain readable, but a
+new public export must either provide a valid closure or use an explicit
+legacy export path with its limitations reported.
+
 Public publication starts from one exact, currently reachable Local Published
 Release; it never accepts a Working Revision, an entire Library, or an
 unreachable historical Release. Use

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scientific-figure-library",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scientific-figure-library",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.4.14",
@@ -35,8 +35,7 @@
       },
       "engines": {
         "node": ">=22"
-      },
-      "author": "xuzhougeng and jarxunlai"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scientific-figure-library",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Local-first MCP server and MCP App for your scientific figures: import, review, and publish a global library on disk, then reuse exact templates in Claude Science and Wisp Science.",
   "keywords": [
     "scientific-figures",

--- a/skills/figure-library/SKILL.md
+++ b/skills/figure-library/SKILL.md
@@ -3,7 +3,7 @@ name: figure-library
 description: Build, review, search, select, and materialize immutable scientific-figure references from Local Published, FigureYa, bundled Open Figure Modules, frozen explicit-only Community, and explicitly trusted dynamic Providers.
 ---
 
-# Scientific Figure Library 0.6.3
+# Scientific Figure Library 0.6.4
 
 Use this Skill when a user wants to store an uploaded figure/code pair, review
 or publish a local template, search for a plotting reference, or materialize an

--- a/src/lifecycle-tools.ts
+++ b/src/lifecycle-tools.ts
@@ -171,12 +171,14 @@ const ReviewAssessmentSchema = z.object({
 });
 
 const AssetOriginSchema = z.record(z.string(), z.unknown()).optional();
+const AssetRightsSchema = z.object({license:z.string().min(1).max(2000),distribution:z.enum(["local_only","public"]),attribution:z.string().max(4000).optional()});
 const VisualAssetSchema = z.object({
   assetId: z.string().regex(SAFE_ID),
   sourcePath: z.string().min(1).max(4_000),
   visualRole: z.enum(["source_reference", "rendered_output"]).optional(),
   mediaType: z.string().min(1).max(200).optional(),
   origin: AssetOriginSchema,
+  rights: AssetRightsSchema.optional(),
 });
 const CodeAssetSchema = z.object({
   assetId: z.string().regex(SAFE_ID),
@@ -187,12 +189,14 @@ const CodeAssetSchema = z.object({
     .optional(),
   mediaType: z.string().min(1).max(200).optional(),
   origin: AssetOriginSchema,
+  rights: AssetRightsSchema.optional(),
 });
 const SupportingAssetSchema = z.object({
   assetId: z.string().regex(SAFE_ID),
   sourcePath: z.string().min(1).max(4_000),
   mediaType: z.string().min(1).max(200).optional(),
   origin: AssetOriginSchema,
+  rights: AssetRightsSchema.optional(),
 });
 const FigureCodeLinkSchema = z.object({
   visualAssetId: z.string().regex(SAFE_ID),
@@ -283,6 +287,7 @@ const WorkingPlanInput = z.object({
   runtime: z.object({
     schema: z.literal("figure-library.runtime-closure.v1"),
     entrypoint: z.string().min(1).max(1_000),
+    dependencies: z.array(z.object({codePath:z.string().min(1),assetPath:z.string().min(1)})).max(100).optional(),
     inputs: z.array(z.object({
       codePath: z.string().min(1).max(1_000),
       assetPath: z.string().min(1).max(1_000),
@@ -618,6 +623,7 @@ async function directCandidate(input: WorkingPlanRequest): Promise<VersionedTemp
       visualPaths.set(asset.assetId, logicalPath);
       assets.push({
         logicalPath,
+        ...(asset.rights ? {rights:asset.rights}: {}),
         role: "visual",
         visualRole: asset.visualRole!,
         sourcePath: asset.sourcePath,
@@ -629,6 +635,7 @@ async function directCandidate(input: WorkingPlanRequest): Promise<VersionedTemp
       codePaths.set(asset.assetId, logicalPath);
       assets.push({
         logicalPath,
+        ...(asset.rights ? {rights:asset.rights}: {}),
         role: "code",
         codeOrigin: asset.codeOrigin!,
         sourcePath: asset.sourcePath,
@@ -640,6 +647,7 @@ async function directCandidate(input: WorkingPlanRequest): Promise<VersionedTemp
       logicalPath = `${asset.category === "reference" ? "references" : "evidence"}/${asset.assetId}${extension}`;
       assets.push({
         logicalPath,
+        ...(asset.rights ? {rights:asset.rights}: {}),
         role: asset.category,
         sourcePath: asset.sourcePath,
         ...(asset.mediaType ? { mediaType: asset.mediaType } : {}),

--- a/src/lifecycle-tools.ts
+++ b/src/lifecycle-tools.ts
@@ -280,6 +280,17 @@ const WorkingPlanInput = z.object({
   agentAssessment: z.record(z.string(), z.unknown()).optional(),
   validationState: ValidationStateSchema.optional(),
   provenance: z.record(z.string(), z.unknown()).optional(),
+  runtime: z.object({
+    schema: z.literal("figure-library.runtime-closure.v1"),
+    entrypoint: z.string().min(1).max(1_000),
+    inputs: z.array(z.object({
+      codePath: z.string().min(1).max(1_000),
+      assetPath: z.string().min(1).max(1_000),
+      required: z.literal(true),
+      role: z.enum(["example_data", "source_data", "private_reference"]),
+    })).max(1_000),
+    output: z.object({ previewPath: z.string().min(1).max(1_000), mediaType: z.literal("image/png") }),
+  }).optional(),
 });
 
 const WorkingApplyInput = z.object({
@@ -810,6 +821,7 @@ async function directCandidate(input: WorkingPlanRequest): Promise<VersionedTemp
     },
     figureCodeLinks,
     provenance: input.provenance ? jsonValue(input.provenance) : undefined,
+    runtime: input.runtime,
     annotations: jsonValue({
       schema: "figure-library.direct-intake-decision.v1",
       executionClaim: visualInference ? "inspired_by_not_reproduced" : executionStatus,

--- a/src/open-figure-module.ts
+++ b/src/open-figure-module.ts
@@ -148,10 +148,8 @@ function publicDataPath(logicalPath: string, used: Set<string>, referencedNames:
   const exact = referencedNames.get(sourceKey) ?? tokenMatch?.[1];
   const name = exact ?? (candidates.length === 1 ? candidates[0]![1] : sourceName);
   let pathValue = `data/${name || "input.csv"}`;
-  let index = 2;
   while (used.has(pathValue)) {
-    pathValue = `data/${index}-${name}`;
-    index += 1;
+    throw new Error(`Open Figure module path collision: ${pathValue}; declare a unique runtime input path instead of renaming the asset`);
   }
   return pathValue;
 }
@@ -159,14 +157,24 @@ function publicDataPath(logicalPath: string, used: Set<string>, referencedNames:
 function runtimePublicDataPath(logicalPath: string, runtimeInputs: Map<string, string>, used: Set<string>, fallback: string) {
   const requested = runtimeInputs.get(logicalPath);
   if (!requested) return fallback;
-  const name = basename(requested).replace(/[^A-Za-z0-9._-]/gu, "-");
-  let pathValue = `data/${name}`;
-  let index = 2;
-  while (used.has(pathValue)) {
-    pathValue = `data/${index}-${name}`;
-    index += 1;
-  }
+  if (!requested.startsWith("data/")) throw new Error(`runtime input public path must be under data/: ${requested}`);
+  const pathValue = requested;
+  if (used.has(pathValue)) throw new Error(`Open Figure module path collision: ${pathValue}; runtime inputs must have unique public paths`);
   return pathValue;
+}
+
+function publicAssetLicense(asset: StoredRevisionAsset, expected: "code" | "content", logicalPath: string) {
+  if (!asset.rights || asset.rights.distribution !== "public" || !asset.rights.license.trim()) {
+    throw new Error(`Open Figure public asset lacks an explicit public redistribution right: ${logicalPath}`);
+  }
+  if (expected === "code" && asset.rights.license.trim().toLocaleLowerCase("en-US") !== "mit") {
+    throw new Error(`Open Figure public code must be licensed MIT: ${logicalPath}`);
+  }
+  const lower = asset.rights.license.toLocaleLowerCase("en-US");
+  if (/(?:unknown|private_reference|unlicensed)/u.test(lower)) {
+    throw new Error(`Open Figure public asset has non-public rights: ${logicalPath}`);
+  }
+  return asset.rights.license.trim();
 }
 
 function jpegThumbnail(pngBytes: Uint8Array) {
@@ -237,6 +245,7 @@ function yamlModule(options: {
     executionScope: "synthetic_data" | "example_data" | "real_data" | "unknown";
     evidence?: string[];
   };
+  licenses: { code: string; content: string; documentation: string };
 }) {
   const document = {
     schema: OPEN_FIGURE_MODULE_SCHEMA,
@@ -258,11 +267,7 @@ function yamlModule(options: {
     files: options.files,
     preview: options.preview,
     thumbnail: options.thumbnail,
-    licenses: {
-      code: "MIT",
-      content: "CC BY 4.0",
-      documentation: "CC BY 4.0",
-    },
+    licenses: options.licenses,
     publisher: options.publisher,
     provenance: [
       {
@@ -329,6 +334,7 @@ export async function buildOpenFigureModule(options: {
   const runtimeInputs = new Map(
     (options.content.runtime?.inputs ?? []).map((input) => [input.assetPath, input.codePath]),
   );
+  const publicContentLicenses = new Set<string>();
   const addFile = (pathValue: string, bytes: Uint8Array, mediaType: string) => {
     if (usedPaths.has(pathValue)) throw new Error(`Open Figure module path collision: ${pathValue}`);
     scanBytes(pathValue, bytes, mediaType);
@@ -344,7 +350,7 @@ export async function buildOpenFigureModule(options: {
     const includeCode = asset.role === "code" && asset.logicalPath === canonicalPath;
     const includeData =
       asset.role === "reference" &&
-      PUBLIC_DATA_EXTENSIONS.test(asset.logicalPath);
+      (PUBLIC_DATA_EXTENSIONS.test(asset.logicalPath) || runtimeInputs.has(asset.logicalPath));
     const includeDocs =
       asset.role === "reference" &&
       /\.(?:md|txt)$/iu.test(asset.logicalPath) &&
@@ -377,19 +383,23 @@ export async function buildOpenFigureModule(options: {
       continue;
     }
     if (includePreview) {
+      publicAssetLicense(asset, "content", asset.logicalPath);
       addFile("preview.png", loaded.bytes, "image/png");
       continue;
     }
     if (includeCode) {
+      publicAssetLicense(asset, "code", asset.logicalPath);
       addFile("code/organized.R", loaded.bytes, asset.mediaType);
       continue;
     }
     if (includeData) {
+      publicContentLicenses.add(publicAssetLicense(asset, "content", asset.logicalPath));
       const fallback = publicDataPath(asset.logicalPath, usedPaths, referencedNames);
       addFile(runtimePublicDataPath(asset.logicalPath, runtimeInputs, usedPaths, fallback), loaded.bytes, asset.mediaType);
       continue;
     }
     if (includeDocs) {
+      publicContentLicenses.add(publicAssetLicense(asset, "content", asset.logicalPath));
       const name = basename(asset.logicalPath).toLocaleLowerCase("en-US") === "readme.md" ? "README.md" : `docs/${basename(asset.logicalPath)}`;
       addFile(name, loaded.bytes, asset.mediaType);
     }
@@ -427,6 +437,12 @@ export async function buildOpenFigureModule(options: {
   const dataProfile = options.content.dataProfile.trim() || "Example or synthetic plotting inputs.";
   const tags = uniqueSorted(options.content.tags.length ? options.content.tags : [moduleId, options.content.plotFamily]);
   const packages = uniqueSorted(options.content.packages);
+  if (!canonicalAsset.rights || canonicalAsset.rights.distribution !== "public") {
+    throw new Error(`Open Figure canonical code requires an explicit public rights declaration: ${canonicalPath}`);
+  }
+  if (!previewAsset.rights || previewAsset.rights.distribution !== "public") {
+    throw new Error(`Open Figure generated preview requires an explicit public rights declaration: ${previewPath}`);
+  }
   if (!fileMap.has("README.md")) {
     addFile(
       "README.md",
@@ -484,6 +500,11 @@ export async function buildOpenFigureModule(options: {
     preview: { path: "preview.png", bytes: previewStat.bytes.byteLength, sha256: previewStat.sha256, mediaType: "image/png" },
     thumbnail: { path: "thumbnail.jpg", bytes: thumbnailStat.bytes.byteLength, sha256: thumbnailStat.sha256, mediaType: "image/jpeg" },
     publisher,
+    licenses: {
+      code: publicAssetLicense(canonicalAsset, "code", canonicalPath),
+      content: [...publicContentLicenses].sort(compareCanonicalStrings).join("; ") || "CC BY 4.0",
+      documentation: "CC BY 4.0",
+    },
   });
   addFile("module.yml", utf8(moduleYaml), "application/yaml");
   const finalFiles = [...fileMap.entries()]

--- a/src/open-figure-module.ts
+++ b/src/open-figure-module.ts
@@ -156,6 +156,19 @@ function publicDataPath(logicalPath: string, used: Set<string>, referencedNames:
   return pathValue;
 }
 
+function runtimePublicDataPath(logicalPath: string, runtimeInputs: Map<string, string>, used: Set<string>, fallback: string) {
+  const requested = runtimeInputs.get(logicalPath);
+  if (!requested) return fallback;
+  const name = basename(requested).replace(/[^A-Za-z0-9._-]/gu, "-");
+  let pathValue = `data/${name}`;
+  let index = 2;
+  while (used.has(pathValue)) {
+    pathValue = `data/${index}-${name}`;
+    index += 1;
+  }
+  return pathValue;
+}
+
 function jpegThumbnail(pngBytes: Uint8Array) {
   const png = PNG.sync.read(Buffer.from(pngBytes), { checkCRC: true });
   const width = png.width;
@@ -313,6 +326,9 @@ export async function buildOpenFigureModule(options: {
     logicalPath: canonicalPath,
   });
   const referencedNames = referencedDataNames(Buffer.from(canonicalLoaded.bytes).toString("utf8"));
+  const runtimeInputs = new Map(
+    (options.content.runtime?.inputs ?? []).map((input) => [input.assetPath, input.codePath]),
+  );
   const addFile = (pathValue: string, bytes: Uint8Array, mediaType: string) => {
     if (usedPaths.has(pathValue)) throw new Error(`Open Figure module path collision: ${pathValue}`);
     scanBytes(pathValue, bytes, mediaType);
@@ -369,7 +385,8 @@ export async function buildOpenFigureModule(options: {
       continue;
     }
     if (includeData) {
-      addFile(publicDataPath(asset.logicalPath, usedPaths, referencedNames), loaded.bytes, asset.mediaType);
+      const fallback = publicDataPath(asset.logicalPath, usedPaths, referencedNames);
+      addFile(runtimePublicDataPath(asset.logicalPath, runtimeInputs, usedPaths, fallback), loaded.bytes, asset.mediaType);
       continue;
     }
     if (includeDocs) {

--- a/src/open-figure-module.ts
+++ b/src/open-figure-module.ts
@@ -120,14 +120,24 @@ function uniqueSorted(values: string[]) {
   return [...new Set(values.map((item) => item.trim()).filter(Boolean))].sort(compareCanonicalStrings);
 }
 
-function codePublicPath(asset: StoredRevisionAsset, canonicalPath: string) {
+function codePublicPath(asset: StoredRevisionAsset, canonicalPath: string, used: Set<string>) {
   if (asset.logicalPath === canonicalPath) {
     const ext = extension(asset.logicalPath) === ".py" ? ".py" : ".R";
     return `code/organized${ext === ".py" ? ".py" : ".R"}`;
   }
-  const ext = extension(asset.logicalPath);
-  if (ext === ".py") return "code/example.py";
-  return "code/example.R";
+  const ext = extension(asset.logicalPath) === ".py" ? ".py" : ".R";
+  // A revision may contain several non-canonical code assets.  Mapping all of
+  // them to code/example.R used to make publication fail deterministically.
+  // Keep the public names portable and derive the suffix from the immutable
+  // asset identity so plans remain reproducible across runs.
+  const digest = typeof asset.sha256 === "string" ? asset.sha256.slice(0, 8) : "asset";
+  let pathValue = `code/example-${digest}${ext}`;
+  let index = 2;
+  while (used.has(pathValue)) {
+    pathValue = `code/example-${digest}-${index}${ext}`;
+    index += 1;
+  }
+  return pathValue;
 }
 
 function dataPublicPath(logicalPath: string, used: Set<string>) {
@@ -344,7 +354,7 @@ export async function buildOpenFigureModule(options: {
       continue;
     }
     if (includeCode) {
-      addFile(codePublicPath(asset, canonicalPath), loaded.bytes, asset.mediaType);
+      addFile(codePublicPath(asset, canonicalPath, usedPaths), loaded.bytes, asset.mediaType);
       continue;
     }
     if (includeData) {

--- a/src/open-figure-module.ts
+++ b/src/open-figure-module.ts
@@ -105,6 +105,10 @@ function scanText(pathValue: string, text: string) {
   }
 }
 
+function containsPrivateText(text: string) {
+  return PRIVATE_PATH.test(text) || TOKEN.test(text) || PRIVATE_KEY.test(text);
+}
+
 function scanBytes(pathValue: string, bytes: Uint8Array, mediaType: string) {
   if (bytes.byteLength > MAX_FILE_BYTES) throw new Error(`public asset exceeds the file size limit: ${pathValue}`);
   if (FORBIDDEN_PUBLIC_FILE.test(pathValue)) throw new Error(`forbidden public path: ${pathValue}`);
@@ -120,18 +124,29 @@ function uniqueSorted(values: string[]) {
   return [...new Set(values.map((item) => item.trim()).filter(Boolean))].sort(compareCanonicalStrings);
 }
 
-function codePublicPath(asset: StoredRevisionAsset, canonicalPath: string) {
-  if (asset.logicalPath === canonicalPath) {
-    const ext = extension(asset.logicalPath) === ".py" ? ".py" : ".R";
-    return `code/organized${ext === ".py" ? ".py" : ".R"}`;
+const PUBLIC_DATA_EXTENSIONS = /\.(?:csv|tsv|txt|nwk|newick|fasta|fa|fas|aln|phy|trees?|xlsx|xls)$/iu;
+
+function referencedDataNames(sourceCode: string) {
+  const names = new Map<string, string>();
+  const pattern = /["']([A-Za-z0-9][A-Za-z0-9._-]*\.(?:csv|tsv|txt|nwk|newick|fasta|fa|fas|aln|phy|trees?|xlsx|xls))["']/giu;
+  for (const match of sourceCode.matchAll(pattern)) {
+    const original = match[1]!;
+    names.set(original.toLocaleLowerCase("en-US"), original);
   }
-  const ext = extension(asset.logicalPath);
-  if (ext === ".py") return "code/example.py";
-  return "code/example.R";
+  return names;
 }
 
-function dataPublicPath(logicalPath: string, used: Set<string>) {
-  const name = basename(logicalPath).replace(/[^A-Za-z0-9._-]/gu, "-");
+function publicDataPath(logicalPath: string, used: Set<string>, referencedNames: Map<string, string>) {
+  const sourceName = basename(logicalPath).replace(/[^A-Za-z0-9._-]/gu, "-");
+  const sourceKey = sourceName.toLocaleLowerCase("en-US");
+  const candidates = [...referencedNames.entries()]
+    .filter(([name]) => extension(name) === extension(sourceName));
+  const tokenMatch = candidates.find((name) => {
+    const sourceTokens = sourceKey.split(/[-_.]+/u).filter((token) => token.length >= 4);
+    return sourceTokens.some((token) => name[0].includes(token));
+  });
+  const exact = referencedNames.get(sourceKey) ?? tokenMatch?.[1];
+  const name = exact ?? (candidates.length === 1 ? candidates[0]![1] : sourceName);
   let pathValue = `data/${name || "input.csv"}`;
   let index = 2;
   while (used.has(pathValue)) {
@@ -242,8 +257,8 @@ function yamlModule(options: {
         note: `Prepared from the reviewed Local Published entry ${options.moduleId}; internal Library state is not distributed.`,
       },
       {
-        type: "synthetic_data",
-        note: "Example inputs were generated for portable execution and do not represent real samples or scientific conclusions.",
+        type: "public_input_scope",
+        note: "Only explicitly selected public input assets are distributed; Local Published execution and scientific-validation claims are not inherited.",
       },
       {
         type: "clean_room_transformation",
@@ -291,6 +306,13 @@ export async function buildOpenFigureModule(options: {
   const usedPaths = new Set<string>();
   const fileMap = new Map<string, Uint8Array>();
   const excludedLogicalPaths: string[] = [];
+  const canonicalLoaded = await options.library.readAsset({
+    templateId: options.content.templateId,
+    revisionId: options.content.revisionId,
+    contentDigest: options.content.contentDigest,
+    logicalPath: canonicalPath,
+  });
+  const referencedNames = referencedDataNames(Buffer.from(canonicalLoaded.bytes).toString("utf8"));
   const addFile = (pathValue: string, bytes: Uint8Array, mediaType: string) => {
     if (usedPaths.has(pathValue)) throw new Error(`Open Figure module path collision: ${pathValue}`);
     scanBytes(pathValue, bytes, mediaType);
@@ -303,15 +325,10 @@ export async function buildOpenFigureModule(options: {
       excludedLogicalPaths.push(asset.logicalPath);
       continue;
     }
-    const includeCode =
-      asset.role === "code" &&
-      (asset.logicalPath === canonicalPath ||
-        asset.codeOrigin === "user_supplied" ||
-        asset.codeOrigin === "adapted" ||
-        asset.codeOrigin === "agent_generated");
+    const includeCode = asset.role === "code" && asset.logicalPath === canonicalPath;
     const includeData =
       asset.role === "reference" &&
-      /\.(?:csv|tsv|txt)$/iu.test(asset.logicalPath);
+      PUBLIC_DATA_EXTENSIONS.test(asset.logicalPath);
     const includeDocs =
       asset.role === "reference" &&
       /\.(?:md|txt)$/iu.test(asset.logicalPath) &&
@@ -339,16 +356,20 @@ export async function buildOpenFigureModule(options: {
       contentDigest: options.content.contentDigest,
       logicalPath: asset.logicalPath,
     });
+    if (includeDocs && containsPrivateText(Buffer.from(loaded.bytes).toString("utf8"))) {
+      excludedLogicalPaths.push(asset.logicalPath);
+      continue;
+    }
     if (includePreview) {
       addFile("preview.png", loaded.bytes, "image/png");
       continue;
     }
     if (includeCode) {
-      addFile(codePublicPath(asset, canonicalPath), loaded.bytes, asset.mediaType);
+      addFile("code/organized.R", loaded.bytes, asset.mediaType);
       continue;
     }
     if (includeData) {
-      addFile(dataPublicPath(asset.logicalPath, usedPaths), loaded.bytes, asset.mediaType);
+      addFile(publicDataPath(asset.logicalPath, usedPaths, referencedNames), loaded.bytes, asset.mediaType);
       continue;
     }
     if (includeDocs) {
@@ -361,6 +382,16 @@ export async function buildOpenFigureModule(options: {
   const canonicalCode = [...fileMap.keys()].find((pathValue) => pathValue.startsWith("code/organized.")) ??
     [...fileMap.keys()].find((pathValue) => pathValue.startsWith("code/"));
   if (!canonicalCode) throw new Error("Open Figure publication is missing canonical code");
+  const publicDataNames = new Set(
+    [...fileMap.keys()]
+      .filter((pathValue) => pathValue.startsWith("data/"))
+      .map((pathValue) => basename(pathValue).toLocaleLowerCase("en-US")),
+  );
+  for (const original of referencedNames.values()) {
+    if (!publicDataNames.has(original.toLocaleLowerCase("en-US"))) {
+      throw new Error(`Open Figure module is missing referenced public input: ${original}`);
+    }
+  }
   const thumbnail = jpegThumbnail(fileMap.get("preview.png")!);
   addFile("thumbnail.jpg", thumbnail, "image/jpeg");
 
@@ -400,11 +431,12 @@ export async function buildOpenFigureModule(options: {
   }
   const codeFiles = [...fileMap.keys()].filter((pathValue) => pathValue.startsWith("code/")).sort(compareCanonicalStrings);
   const inputFiles = [...fileMap.keys()].filter((pathValue) => pathValue.startsWith("data/") && pathValue !== "data_schema.yml").sort(compareCanonicalStrings);
-  const executionStatus = options.content.validationState?.plotExecution.status ??
-    (options.content.executionStatus === "passed" || options.content.executionStatus === "failed" || options.content.executionStatus === "not_run"
-      ? options.content.executionStatus
-      : "not_run");
-  const executionScope = options.content.validationState?.plotExecution.scope ?? "synthetic_data";
+  // A Local Published execution claim is not evidence that this sanitized
+  // public module was executed. The host-side render receipt is the only
+  // source of public-package execution status and is attached by the PR
+  // workflow after the clean staging directory has been run.
+  const executionStatus = "not_run" as const;
+  const executionScope = "unknown" as const;
   const files = [...fileMap.keys(), "module.yml"].sort(compareCanonicalStrings);
   if (files.length > MAX_FILES) throw new Error("Open Figure module contains too many files");
   const requiredFiles = files.filter((pathValue) => pathValue !== "provenance.md");
@@ -414,7 +446,6 @@ export async function buildOpenFigureModule(options: {
     reviewStatus: "approved" as const,
     executionStatus,
     executionScope,
-    ...(executionStatus === "passed" ? { evidence: ["preview.png"] } : {}),
   };
   const moduleYaml = yamlModule({
     moduleId,

--- a/src/portable-bundles.ts
+++ b/src/portable-bundles.ts
@@ -1580,6 +1580,7 @@ export class PortableBundleManager {
     const requiredAssetSha256 = content.assets.map((asset) => asset.sha256).sort();
     const importId = `bundle-${sha256(`${bundle.bundleId}:${targetTemplateId}`).slice(0, 24)}`;
     const candidate: VersionedTemplateCandidate = {
+      ...(content.runtime ? {runtime:content.runtime}: {}),
       title: content.title,
       description: content.description,
       tags: content.tags,
@@ -1617,6 +1618,7 @@ export class PortableBundleManager {
       },
       assets: content.assets.map((asset: StoredRevisionAsset) => ({
         logicalPath: asset.logicalPath,
+        ...(asset.rights ? {rights:asset.rights}: {}),
         role: asset.role,
         ...(asset.visualRole ? { visualRole: asset.visualRole } : {}),
         ...(asset.codeOrigin ? { codeOrigin: asset.codeOrigin } : {}),

--- a/src/runtime-closure.ts
+++ b/src/runtime-closure.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+import { assertPortableFilesystemSegment, portableCaseFold } from './library-runtime.ts';
+
+/** Paths are relative to the exported module root, not the current project. */
+export function runtimePath(value: string) {
+  if (typeof value !== 'string' || !value || value.includes('\\') || path.posix.isAbsolute(value) || /^[A-Za-z]:/u.test(value) || path.posix.normalize(value) !== value || value.split('/').some(p => p === '..' || p === '.')) throw new Error(`unsafe runtime path: ${value}`);
+  for (const segment of value.split('/')) assertPortableFilesystemSegment(segment, 'runtime path');
+  if (value.split('/').some(p => /^(gallery|inbox)$/i.test(p))) throw new Error(`runtime path depends on pre-publication directory: ${value}`);
+  return value;
+}
+
+// A bounded R file-I/O scanner, not an R interpreter. Unknown/dynamic expressions
+// are explicitly reported rather than guessing from extensions or basenames.
+interface Token { value: string; string?: boolean; line: number }
+function tokens(code: string): Token[] {
+  const out: Token[] = []; let i = 0, line = 1;
+  while (i < code.length) {
+    const c = code[i]!;
+    if (c === '\n') { line++; i++; continue; }
+    if (/\s/.test(c)) { i++; continue; }
+    if (c === '#') { while (i < code.length && code[i] !== '\n') i++; continue; }
+    if (c === '"' || c === "'") {
+      const quote = c; let s = ''; i++;
+      while (i < code.length && code[i] !== quote) { if (code[i] === '\\') { s += code[i++]!; if (i < code.length) s += code[i++]!; } else s += code[i++]!; }
+      i++; out.push({ value: s, string: true, line }); continue;
+    }
+    const word = /^[A-Za-z_.][A-Za-z0-9_.]*/.exec(code.slice(i));
+    if (word) { out.push({ value: word[0], line }); i += word[0].length; continue; }
+    const op = ['<-','::','=='].find(op => code.startsWith(op, i));
+    out.push({ value: op ?? c, line }); i += op?.length ?? 1;
+  }
+  return out;
+}
+function argumentsAt(t: Token[], start: number) {
+  const args: Token[][] = []; let cur: Token[] = [], depth = 0, end = start;
+  for (let i = start; i < t.length; i++) {
+    const tok = t[i]!;
+    if (tok.value === ')' && depth === 0) { args.push(cur); end = i; return { args, end }; }
+    if (tok.value === ',' && depth === 0) { args.push(cur); cur = []; continue; }
+    if (tok.value === '(' || tok.value === '[') depth++;
+    if (tok.value === ')' || tok.value === ']') depth--;
+    cur.push(tok);
+  }
+  return { args: [], end };
+}
+const READERS = new Set(['read.csv','read.csv2','read.delim','read.table','readLines','readRDS','load','read.tree','read.newick','read.dna','read_csv','read_tsv','read_delim','read_excel','read_xlsx','readDNAStringSet','readAAStringSet','fread','source','sys.source','read_fasta']);
+export interface RuntimeRead { path?: string; expression: string; line: number; kind: 'code'|'data' }
+export function inspectRuntimeReads(code: string): RuntimeRead[] {
+  const t = tokens(code), bindings = new Map<string, Token[]>();
+  for (let i = 0; i < t.length - 2; i++) {
+    if (!t[i]!.string && ['<-','='].includes(t[i + 1]!.value)) {
+      let j = i + 2, depth = 0; const expr: Token[] = [];
+      while (j < t.length) {
+        const tok = t[j]!;
+        if (depth === 0 && (tok.line > t[i + 2]!.line || [',',';',')','}'].includes(tok.value))) break;
+        if (tok.value === '(') depth++; if (tok.value === ')') depth--;
+        expr.push(tok); j++;
+      }
+      bindings.set(t[i]!.value, expr);
+    }
+  }
+  const resolve = (e: Token[], seen = new Set<string>()): string | undefined => {
+    if (e[1]?.value === '=') e = e.slice(2);
+    if (e.length === 1 && e[0]!.string) return e[0]!.value;
+    if (e.length === 1) {
+      const name = e[0]!.value;
+      if (name === 'root') return '';
+      if (name === 'script_dir') return 'code';
+      if (seen.has(name)) return;
+      const expr = bindings.get(name); return expr ? resolve(expr, new Set([...seen,name])) : undefined;
+    }
+    if (e[0]?.value === 'file.path' && e[1]?.value === '(') {
+      const { args } = argumentsAt(e, 2), parts = args.map(a => resolve(a, seen));
+      if (parts.some(p => p === undefined)) return;
+      // Do not normalize away traversal: runtimePath must reject it.
+      return parts.filter(p => p !== '').join('/');
+    }
+    return undefined;
+  };
+  const reads: RuntimeRead[] = [];
+  for (let i = 0; i < t.length - 1; i++) {
+    const name = t[i]!.value;
+    if (t[i]!.string || !READERS.has(name) || t[i + 1]!.value !== '(') continue;
+    const { args } = argumentsAt(t, i + 2);
+    // text= constructs a tree/table in memory; it is not a file input.
+    if (args.some(a => a[0]?.value === 'text' && a[1]?.value === '=')) continue;
+    const fileArg = args.find(a => ['file','path','con','input'].includes(a[0]?.value ?? '') && a[1]?.value === '=') ?? args[0] ?? [];
+    reads.push({ path: resolve(fileArg), expression: fileArg.map(t => t.string ? JSON.stringify(t.value) : t.value).join(''), line: t[i]!.line, kind: /source$/.test(name) ? 'code' : 'data' });
+  }
+  return reads;
+}
+export function assertRuntimeReads(code: string, declared: string[], label: string) {
+  const known = new Set(declared.map(runtimePath));
+  for (const read of inspectRuntimeReads(code)) {
+    if (read.path === undefined) throw new Error(`${label}: unresolved runtime input ${read.expression} at line ${read.line}; use an explicit module-relative file path`);
+    const requested = runtimePath(read.path);
+    if (!known.has(requested)) throw new Error(`${label}: missing runtime input ${requested} at line ${read.line}`);
+  }
+}
+export function assertUniqueRuntimePaths(values: string[]) {
+  const seen = new Set<string>();
+  for (const value of values) { const key = portableCaseFold(runtimePath(value)); if (seen.has(key)) throw new Error(`duplicate runtime path: ${value}`); seen.add(key); }
+}

--- a/src/versioned-library.ts
+++ b/src/versioned-library.ts
@@ -1,3 +1,4 @@
+import { runtimePath, assertUniqueRuntimePaths, inspectRuntimeReads, assertRuntimeReads } from "./runtime-closure.ts";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -88,7 +89,14 @@ export type CodeAssetOrigin =
   | "adapted";
 export type ReviewSource = "system" | "rule" | "agent" | "user" | "migration";
 
+export interface AssetRights {
+  license: string;
+  distribution: "local_only" | "public";
+  attribution?: string;
+}
+
 export interface RevisionAssetInput {
+  rights?: AssetRights;
   logicalPath: string;
   role: RevisionAssetRole;
   visualRole?: VisualAssetRole;
@@ -102,6 +110,7 @@ export interface RevisionAssetInput {
 }
 
 export interface StoredRevisionAsset {
+  rights?: AssetRights;
   logicalPath: string;
   file: string;
   role: RevisionAssetRole;
@@ -208,6 +217,7 @@ export interface RuntimeClosureV1 {
   schema: "figure-library.runtime-closure.v1";
   entrypoint: string;
   inputs: RuntimeClosureInputV1[];
+  dependencies?: Array<{ codePath: string; assetPath: string }>;
   output: { previewPath: string; mediaType: "image/png" };
 }
 
@@ -912,6 +922,12 @@ function assertNoAbsoluteFilesystemPaths(value: JsonValue, label: string): JsonV
   return jsonClone(value);
 }
 
+function normalizeAssetRights(value: unknown): AssetRights | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value) || typeof value.license !== "string" || !value.license.trim() || !["local_only", "public"].includes(String(value.distribution)) || (value.attribution !== undefined && typeof value.attribution !== "string")) throw new Error("invalid asset rights");
+  return { license: value.license.trim(), distribution: value.distribution as AssetRights["distribution"], ...(value.attribution ? {attribution: value.attribution as string} : {}) };
+}
+
 function normalizeRuntimeClosure(
   value: unknown,
   assetsByPath: Map<string, StoredRevisionAsset>,
@@ -924,6 +940,7 @@ function normalizeRuntimeClosure(
   }
   if (typeof value.entrypoint !== "string" || !value.entrypoint.trim()) throw new Error("runtime.entrypoint is required");
   const entrypoint = validateRevisionAssetPath(value.entrypoint);
+  if (assetsByPath.get(entrypoint)?.role !== "code") throw new Error("runtime.entrypoint must reference code");
   if (canonicalPath && entrypoint !== canonicalPath) throw new Error("runtime.entrypoint must equal canonicalImplementation.assetPath");
   if (!Array.isArray(value.inputs)) throw new Error("runtime.inputs must be an array");
   const seen = new Set<string>();
@@ -932,7 +949,7 @@ function normalizeRuntimeClosure(
         !["example_data", "source_data", "private_reference"].includes(String(raw.role))) {
       throw new Error(`invalid runtime input at index ${index}`);
     }
-    const codePath = validateRevisionAssetPath(raw.codePath);
+    const codePath = runtimePath(raw.codePath);
     const assetPath = validateRevisionAssetPath(raw.assetPath);
     const key = `${codePath}\u0000${assetPath}`;
     if (seen.has(key)) throw new Error(`duplicate runtime input: ${codePath}`);
@@ -940,13 +957,20 @@ function normalizeRuntimeClosure(
     if (assetsByPath.get(assetPath)?.role !== "reference") throw new Error(`runtime input must reference a reference asset: ${assetPath}`);
     return { codePath, assetPath, required: true as const, role: raw.role as RuntimeInputRole };
   });
+  const dependencies = value.dependencies === undefined ? [] : value.dependencies;
+  if (!Array.isArray(dependencies)) throw new Error("invalid runtime dependencies");
+  const codeDependencies = dependencies.map(raw => {
+    if (!isRecord(raw) || typeof raw.codePath !== "string" || typeof raw.assetPath !== "string" || assetsByPath.get(raw.assetPath)?.role !== "code") throw new Error("runtime dependency must reference code");
+    return {codePath: runtimePath(raw.codePath), assetPath: validateRevisionAssetPath(raw.assetPath)};
+  });
+  assertUniqueRuntimePaths(["code/organized.R", "preview.png", ...inputs.map(i=>i.codePath), ...codeDependencies.map(i=>i.codePath)]);
   if (!isRecord(value.output) || value.output.mediaType !== "image/png" || typeof value.output.previewPath !== "string") {
     throw new Error("runtime.output must declare a PNG previewPath");
   }
   const previewPath = validateRevisionAssetPath(value.output.previewPath);
   if (primaryPreview && previewPath !== primaryPreview) throw new Error("runtime.output.previewPath must equal primaryPreview");
   if (assetsByPath.get(previewPath)?.role !== "visual") throw new Error("runtime.output.previewPath must reference a visual asset");
-  return { schema: "figure-library.runtime-closure.v1", entrypoint, inputs, output: { previewPath, mediaType: "image/png" } };
+  return { schema: "figure-library.runtime-closure.v1", entrypoint, inputs: inputs.sort((a,b)=>compareCanonicalStrings(a.codePath,b.codePath)), ...(codeDependencies.length ? {dependencies: codeDependencies.sort((a,b)=>compareCanonicalStrings(a.codePath,b.codePath))} : {}), output: { previewPath, mediaType: "image/png" } };
 }
 
 function assertCanonicalAssetPath(
@@ -1200,6 +1224,7 @@ async function prepareCandidate(options: {
   const caseFoldedPaths = new Set<string>();
   const storedAssets: StoredRevisionAsset[] = [];
   const sources: PreparedAssetSource[] = [];
+  const codeTexts = new Map<string,string>();
   let totalBytes = 0;
   for (const input of candidate.assets) {
     if (!["visual", "code", "reference", "evidence"].includes(input.role)) {
@@ -1234,12 +1259,14 @@ async function prepareCandidate(options: {
     logicalPaths.add(logicalPath);
     caseFoldedPaths.add(folded);
     const { bytes, source } = await readAssetSource({ ...input, logicalPath });
+    if (input.role === "code") codeTexts.set(logicalPath, new TextDecoder().decode(bytes));
     totalBytes += bytes.byteLength;
     if (totalBytes > MAX_REVISION_BYTES) {
       throw new Error(`candidate assets exceed ${MAX_REVISION_BYTES} bytes`);
     }
     storedAssets.push({
       logicalPath,
+      ...(input.rights ? {rights: normalizeAssetRights(input.rights)} : {}),
       file: `assets/${logicalPath}`,
       role: input.role,
       ...(input.visualRole ? { visualRole: input.visualRole } : {}),
@@ -1298,7 +1325,9 @@ async function prepareCandidate(options: {
     throw new Error("canonical implementation must be explicitly selected by the user");
   }
   const runtime = normalizeRuntimeClosure(
-    candidate.runtime,
+    candidate.runtime ?? (candidate.assetKind === "plot_template" && canonicalImplementation && primaryPreview && !inspectRuntimeReads(codeTexts.get(canonicalImplementation.assetPath) ?? "").length ? {
+      schema: "figure-library.runtime-closure.v1", entrypoint: canonicalImplementation.assetPath, inputs: [], output: {previewPath:primaryPreview, mediaType:"image/png"}
+    } : undefined),
     assetsByPath,
     canonicalImplementation?.assetPath,
     primaryPreview,
@@ -1455,6 +1484,15 @@ async function prepareCandidate(options: {
     domainWarnings.push({ id: issueId("warning", base), ...base, source: "rule" });
   };
 
+  if (candidate.assetKind === "plot_template") {
+    if (!runtime) addWarning("runtime_closure_missing", "This legacy revision has no runtime closure; public export requires an explicit closure", "runtime");
+    else {
+      try {
+        const paths = [...runtime.inputs.map(i=>i.codePath), ...(runtime.dependencies ?? []).map(i=>i.codePath)];
+        for (const codePath of [runtime.entrypoint,...(runtime.dependencies ?? []).map(i=>i.assetPath)]) assertRuntimeReads(codeTexts.get(codePath) ?? "", paths, codePath);
+      } catch (e) { addError("runtime_input_incomplete", (e as Error).message, "runtime"); }
+    }
+  }
   if (executionStatusConflict) {
     addError(
       "execution_status_conflicts_with_validation_state",
@@ -2043,6 +2081,7 @@ function validateStoredAsset(value: unknown): StoredRevisionAsset {
     throw new Error(`invalid stored asset language: ${logicalPath}`);
   }
   if (value.origin !== undefined) canonicalJson(value.origin);
+  normalizeAssetRights(value.rights);
   return value as unknown as StoredRevisionAsset;
 }
 
@@ -3533,6 +3572,27 @@ export class VersionedTemplateLibrary {
     });
   }
 
+  async validateRuntimeClosure(content: TemplateContentV1) {
+    if (content.assetKind !== "plot_template") return;
+    const r = normalizeRuntimeClosure(content.runtime, new Map(content.assets.map(a=>[a.logicalPath,a])), content.canonicalImplementation?.assetPath, content.primaryPreview);
+    if (!r) {
+      const canonicalPath = content.canonicalImplementation?.assetPath;
+      if (!canonicalPath) return;
+      const loaded = await this.readAsset({templateId:content.templateId, revisionId:content.revisionId,contentDigest:content.contentDigest,logicalPath:canonicalPath});
+      const reads = inspectRuntimeReads(new TextDecoder().decode(loaded.bytes));
+      if (reads.length) {
+        const first = reads.find((read) => read.kind === "data") ?? reads[0]!;
+        throw new Error(`cannot publish Local Published release: ${content.templateId}/${canonicalPath} requires an explicit runtime closure for ${first.path ?? first.expression} at line ${first.line}`);
+      }
+      return;
+    }
+    const paths = [...r.inputs.map(i=>i.codePath), ...(r.dependencies ?? []).map(i=>i.codePath)];
+    for (const assetPath of [r.entrypoint,...(r.dependencies ?? []).map(i=>i.assetPath)]) {
+      const loaded = await this.readAsset({templateId:content.templateId, revisionId:content.revisionId,contentDigest:content.contentDigest,logicalPath:assetPath});
+      assertRuntimeReads(new TextDecoder().decode(loaded.bytes), paths, `${content.templateId}/${content.revisionId}/${assetPath}`);
+    }
+  }
+
   async planPublish(options: { templateId: string }): Promise<PublishPlan> {
     const series = await this.requireSeries(options.templateId);
     if (series.status === "archived") throw new Error(`template series is archived: ${options.templateId}`);
@@ -3552,6 +3612,7 @@ export class VersionedTemplateLibrary {
     if (openGates.length) {
       throw new Error(`cannot publish with blocking review gates: ${openGates.map((gate) => gate.gateId).join(", ")}`);
     }
+    await this.validateRuntimeClosure(content);
     const publishedAt = nowIso();
     const releaseWithoutDigest: Omit<TemplateReleaseV1, "releaseDigest"> = {
       schema: TEMPLATE_RELEASE_SCHEMA,
@@ -5010,6 +5071,7 @@ export class VersionedTemplateLibrary {
         await atomicWriteJson(this.seriesFile(plan.templateId), nextSeries);
         await this.injectFault("after_series_write", operationIntent);
       } else if (plan.action === "publish") {
+        await this.validateRuntimeClosure(await this.requireContent(plan.templateId,plan.release.revisionId,plan.release.contentDigest));
         if (!current?.workingHead) throw new Error("publish requires a working head");
         const { release } = plan;
         if (

--- a/src/versioned-library.ts
+++ b/src/versioned-library.ts
@@ -195,6 +195,22 @@ export interface IntakeRevisionBinding {
   requiredAssetSha256: string[];
 }
 
+export type RuntimeInputRole = "example_data" | "source_data" | "private_reference";
+
+export interface RuntimeClosureInputV1 {
+  codePath: string;
+  assetPath: string;
+  required: true;
+  role: RuntimeInputRole;
+}
+
+export interface RuntimeClosureV1 {
+  schema: "figure-library.runtime-closure.v1";
+  entrypoint: string;
+  inputs: RuntimeClosureInputV1[];
+  output: { previewPath: string; mediaType: "image/png" };
+}
+
 export interface VersionedTemplateCandidate {
   title: string;
   description?: string;
@@ -219,6 +235,7 @@ export interface VersionedTemplateCandidate {
   provenance?: JsonValue;
   annotations?: JsonValue;
   intakeBinding?: IntakeRevisionBinding;
+  runtime?: RuntimeClosureV1;
   assets: RevisionAssetInput[];
 }
 
@@ -315,6 +332,7 @@ export interface TemplateContentV1 {
   provenance?: JsonValue;
   annotations?: JsonValue;
   intakeBinding?: IntakeRevisionBinding;
+  runtime?: RuntimeClosureV1;
   assets: StoredRevisionAsset[];
   contentDigest: string;
 }
@@ -894,6 +912,43 @@ function assertNoAbsoluteFilesystemPaths(value: JsonValue, label: string): JsonV
   return jsonClone(value);
 }
 
+function normalizeRuntimeClosure(
+  value: unknown,
+  assetsByPath: Map<string, StoredRevisionAsset>,
+  canonicalPath?: string,
+  primaryPreview?: string,
+): RuntimeClosureV1 | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value) || value.schema !== "figure-library.runtime-closure.v1") {
+    throw new Error("invalid runtime closure schema");
+  }
+  if (typeof value.entrypoint !== "string" || !value.entrypoint.trim()) throw new Error("runtime.entrypoint is required");
+  const entrypoint = validateRevisionAssetPath(value.entrypoint);
+  if (canonicalPath && entrypoint !== canonicalPath) throw new Error("runtime.entrypoint must equal canonicalImplementation.assetPath");
+  if (!Array.isArray(value.inputs)) throw new Error("runtime.inputs must be an array");
+  const seen = new Set<string>();
+  const inputs = value.inputs.map((raw, index) => {
+    if (!isRecord(raw) || typeof raw.codePath !== "string" || typeof raw.assetPath !== "string" || raw.required !== true ||
+        !["example_data", "source_data", "private_reference"].includes(String(raw.role))) {
+      throw new Error(`invalid runtime input at index ${index}`);
+    }
+    const codePath = validateRevisionAssetPath(raw.codePath);
+    const assetPath = validateRevisionAssetPath(raw.assetPath);
+    const key = `${codePath}\u0000${assetPath}`;
+    if (seen.has(key)) throw new Error(`duplicate runtime input: ${codePath}`);
+    seen.add(key);
+    if (assetsByPath.get(assetPath)?.role !== "reference") throw new Error(`runtime input must reference a reference asset: ${assetPath}`);
+    return { codePath, assetPath, required: true as const, role: raw.role as RuntimeInputRole };
+  });
+  if (!isRecord(value.output) || value.output.mediaType !== "image/png" || typeof value.output.previewPath !== "string") {
+    throw new Error("runtime.output must declare a PNG previewPath");
+  }
+  const previewPath = validateRevisionAssetPath(value.output.previewPath);
+  if (primaryPreview && previewPath !== primaryPreview) throw new Error("runtime.output.previewPath must equal primaryPreview");
+  if (assetsByPath.get(previewPath)?.role !== "visual") throw new Error("runtime.output.previewPath must reference a visual asset");
+  return { schema: "figure-library.runtime-closure.v1", entrypoint, inputs, output: { previewPath, mediaType: "image/png" } };
+}
+
 function assertCanonicalAssetPath(
   logicalPath: string,
   role: RevisionAssetRole,
@@ -1242,6 +1297,12 @@ async function prepareCandidate(options: {
   if (canonicalImplementation && canonicalImplementation.selectedBy !== "user") {
     throw new Error("canonical implementation must be explicitly selected by the user");
   }
+  const runtime = normalizeRuntimeClosure(
+    candidate.runtime,
+    assetsByPath,
+    canonicalImplementation?.assetPath,
+    primaryPreview,
+  );
 
   const figureCodeLinks = (candidate.figureCodeLinks ?? []).map((link) => ({
     visualAssetPath: validateRevisionAssetPath(link.visualAssetPath),
@@ -1364,6 +1425,7 @@ async function prepareCandidate(options: {
       ? { annotations: assertNoAbsoluteFilesystemPaths(candidate.annotations, "annotations") }
       : {}),
     ...(intakeBinding ? { intakeBinding } : {}),
+    ...(runtime ? { runtime } : {}),
     assets: storedAssets,
   };
   const content: TemplateContentV1 = {
@@ -2146,6 +2208,14 @@ function validateContentValue(
   if (value.assetKind === "visual_reference" && value.canonicalImplementation) {
     throw new Error("visual reference content cannot have a canonical implementation");
   }
+  normalizeRuntimeClosure(
+    value.runtime,
+    byPath,
+    isRecord(value.canonicalImplementation) && typeof value.canonicalImplementation.assetPath === "string"
+      ? value.canonicalImplementation.assetPath
+      : undefined,
+    typeof value.primaryPreview === "string" ? value.primaryPreview : undefined,
+  );
   if (!Array.isArray(value.figureCodeLinks)) throw new Error("invalid figureCodeLinks");
   for (const link of value.figureCodeLinks) {
     if (!isRecord(link) || typeof link.evidence !== "string" || !link.evidence.trim()) {

--- a/tests/open-figure-module.test.ts
+++ b/tests/open-figure-module.test.ts
@@ -177,6 +177,12 @@ test("Open Figure sanitizer keeps generated preview and drops source/original/pr
 test("Open Figure sanitizer publishes only the canonical code and maps a sole data input to its referenced name", async () => {
   const { root, versionedLibrary, content } = await publishedLibrary("portable-ggtree", {
     canonicalImplementation: { assetPath: "code/code-organized.r", selectedBy: "user" },
+    runtime: {
+      schema: "figure-library.runtime-closure.v1",
+      entrypoint: "code/code-organized.r",
+      inputs: [{ codePath: "data/HPV58.nwk", assetPath: "references/tree-nwk.nwk", required: true, role: "example_data" }],
+      output: { previewPath: "visuals/rendered/preview.png", mediaType: "image/png" },
+    },
     visualGrouping: {
       visualAssetPaths: ["visuals/rendered/preview.png"],
       confirmedBy: "user",

--- a/tests/open-figure-module.test.ts
+++ b/tests/open-figure-module.test.ts
@@ -41,6 +41,7 @@ function candidate(overrides: Partial<VersionedTemplateCandidate> = {}): Version
       reason: "Use the generated render as the public preview.",
     },
     canonicalImplementation: { assetPath: "code/code-organized.r", selectedBy: "user" },
+    runtime: {schema:"figure-library.runtime-closure.v1",entrypoint:"code/code-organized.r",inputs:[{codePath:"data/pathway_nes.csv",assetPath:"references/nes-csv.csv",required:true,role:"example_data"}],output:{previewPath:"visuals/rendered/preview.png",mediaType:"image/png"}},
     visualGrouping: {
       visualAssetPaths: ["visuals/source/wechat-heatmap.png", "visuals/rendered/preview.png"],
       confirmedBy: "user",
@@ -75,6 +76,7 @@ function candidate(overrides: Partial<VersionedTemplateCandidate> = {}): Version
         codeOrigin: "adapted",
         language: "R",
         mediaType: "text/x-r-source",
+        rights: { license: "MIT", distribution: "public" },
         text: "input <- read.csv('data/pathway_nes.csv')\nplot(input)\n",
       },
       {
@@ -97,6 +99,7 @@ function candidate(overrides: Partial<VersionedTemplateCandidate> = {}): Version
         logicalPath: "references/nes-csv.csv",
         role: "reference",
         mediaType: "text/csv",
+        rights: { license: "CC BY 4.0", distribution: "public" },
         text: "Pathway,A,B\nGlycolysis,1,2\n",
       },
       {
@@ -110,6 +113,7 @@ function candidate(overrides: Partial<VersionedTemplateCandidate> = {}): Version
         role: "visual",
         visualRole: "rendered_output",
         mediaType: "image/png",
+        rights: { license: "CC BY 4.0", distribution: "public" },
         bytes: new Uint8Array(PNG_BYTES),
       },
       {
@@ -127,7 +131,11 @@ function candidate(overrides: Partial<VersionedTemplateCandidate> = {}): Version
       },
     ],
   };
-  return { ...base, ...overrides, assets: overrides.assets ?? base.assets };
+  const assets = overrides.assets ?? base.assets;
+  const runtime = Object.hasOwn(overrides, "runtime")
+    ? overrides.runtime
+    : (overrides.assets && !base.runtime?.inputs.every((input) => assets.some((asset) => asset.logicalPath === input.assetPath)) ? undefined : base.runtime);
+  return { ...base, ...overrides, runtime, assets };
 }
 
 async function publishedLibrary(templateId: string, overrides: Partial<VersionedTemplateCandidate> = {}) {
@@ -135,10 +143,19 @@ async function publishedLibrary(templateId: string, overrides: Partial<Versioned
   await ensureLibraryRootMarker(root);
   const snapshot = await resolveLibraryRuntimeSnapshot({ root });
   const versionedLibrary = new VersionedTemplateLibrary(snapshot);
+  const prepared = candidate(overrides);
+  prepared.assets = prepared.assets.map((asset) => ({
+    ...asset,
+    rights: asset.rights ?? (asset.role === "code"
+      ? { license: "MIT", distribution: "public" as const }
+      : asset.role === "evidence"
+        ? { license: "local-only", distribution: "local_only" as const }
+        : { license: "CC BY 4.0", distribution: "public" as const }),
+  }));
   await versionedLibrary.applyCreateWorking(
     await versionedLibrary.planCreateWorking({
       templateId,
-      candidate: candidate(overrides),
+      candidate: prepared,
     }),
     `${templateId}-working`,
   );
@@ -203,12 +220,14 @@ test("Open Figure sanitizer publishes only the canonical code and maps a sole da
         codeOrigin: "adapted",
         language: "R",
         mediaType: "text/x-r-source",
+        rights: { license: "MIT", distribution: "public" },
         text: 'tree <- read.tree(file.path(root, "data", "HPV58.nwk"))\n',
       },
       {
         logicalPath: "references/tree-nwk.nwk",
         role: "reference",
         mediaType: "text/plain",
+        rights: { license: "CC BY 4.0", distribution: "public" },
         text: "(a:1,b:1);\n",
       },
       {
@@ -222,6 +241,7 @@ test("Open Figure sanitizer publishes only the canonical code and maps a sole da
         role: "visual",
         visualRole: "rendered_output",
         mediaType: "image/png",
+        rights: { license: "CC BY 4.0", distribution: "public" },
         bytes: new Uint8Array(PNG_BYTES),
       },
     ],
@@ -287,6 +307,7 @@ test("Open Figure sanitizer rejects private machine paths in code", async () => 
         role: "visual",
         visualRole: "rendered_output",
         mediaType: "image/png",
+        rights: { license: "CC BY 4.0", distribution: "public" },
         bytes: new Uint8Array(PNG_BYTES),
       },
     ],
@@ -355,4 +376,43 @@ test("public modules exclude private supporting notes even if misclassified as r
     assert.ok(["references/receipt.md", "references/private_reference.txt", "references/paper.pdf"].every((file) => built.excludedLogicalPaths.includes(file)));
     assert.ok(!built.files.some((file) => new TextDecoder().decode(file.bytes).includes("PRIVATE NOTE")));
   } finally { await fs.rm(root, { recursive: true, force: true }); }
+});
+
+test("Open Figure export blocks a Local Published input without explicit public rights", async () => {
+  const original = candidate();
+  const { root, versionedLibrary, content } = await publishedLibrary("rights-closed-input", {
+    assets: original.assets.map((asset) => asset.logicalPath === "references/nes-csv.csv"
+      ? { ...asset, rights: { license: "CC BY-NC-ND", distribution: "local_only" as const } }
+      : asset),
+  });
+  try {
+    await assert.rejects(
+      () => buildOpenFigureModule({ library: versionedLibrary, content }),
+      /explicit public redistribution right|non-public rights/u,
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Local Published promotion blocks a code input closure that is only implicit", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "sfl-runtime-closure-promotion-"));
+  await ensureLibraryRootMarker(root);
+  const snapshot = await resolveLibraryRuntimeSnapshot({ root });
+  const versionedLibrary = new VersionedTemplateLibrary(snapshot);
+  await versionedLibrary.applyCreateWorking(
+    await versionedLibrary.planCreateWorking({
+      templateId: "runtime-closure-required",
+      candidate: candidate({ runtime: undefined }),
+    }),
+    "runtime-closure-required-working",
+  );
+  try {
+    await assert.rejects(
+      () => versionedLibrary.planPublish({ templateId: "runtime-closure-required" }),
+      /requires an explicit runtime closure/u,
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 });

--- a/tests/open-figure-module.test.ts
+++ b/tests/open-figure-module.test.ts
@@ -158,6 +158,7 @@ test("Open Figure sanitizer keeps generated preview and drops source/original/pr
     const built = await buildOpenFigureModule({ library: versionedLibrary, content });
     const paths = built.files.map((file) => file.path);
     assert.ok(paths.includes("code/organized.R"));
+    assert.ok(!paths.includes("code/example.R"));
     assert.ok(paths.includes("preview.png"));
     assert.ok(paths.includes("thumbnail.jpg"));
     assert.ok(paths.includes("module.yml"));
@@ -168,6 +169,65 @@ test("Open Figure sanitizer keeps generated preview and drops source/original/pr
     assert.match(yaml, /code: MIT/u);
     assert.doesNotMatch(yaml, /private_reference/u);
     assert.equal(built.titleEnDerived, true);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Open Figure sanitizer publishes only the canonical code and maps a sole data input to its referenced name", async () => {
+  const { root, versionedLibrary, content } = await publishedLibrary("portable-ggtree", {
+    canonicalImplementation: { assetPath: "code/code-organized.r", selectedBy: "user" },
+    visualGrouping: {
+      visualAssetPaths: ["visuals/rendered/preview.png"],
+      confirmedBy: "user",
+    },
+    figureCodeLinks: [
+      {
+        visualAssetPath: "visuals/rendered/preview.png",
+        codeAssetPaths: ["code/code-organized.r"],
+        relationship: "generated_output",
+        confirmedBy: "user",
+        evidence: "The organized script generated the rendered preview.",
+      },
+    ],
+    assets: [
+      {
+        logicalPath: "code/code-organized.r",
+        role: "code",
+        codeOrigin: "adapted",
+        language: "R",
+        mediaType: "text/x-r-source",
+        text: 'tree <- read.tree(file.path(root, "data", "HPV58.nwk"))\n',
+      },
+      {
+        logicalPath: "references/tree-nwk.nwk",
+        role: "reference",
+        mediaType: "text/plain",
+        text: "(a:1,b:1);\n",
+      },
+      {
+        logicalPath: "evidence/run.md",
+        role: "evidence",
+        mediaType: "text/markdown",
+        text: "Local-only execution note.\n",
+      },
+      {
+        logicalPath: "visuals/rendered/preview.png",
+        role: "visual",
+        visualRole: "rendered_output",
+        mediaType: "image/png",
+        bytes: new Uint8Array(PNG_BYTES),
+      },
+    ],
+  });
+  try {
+    const built = await buildOpenFigureModule({ library: versionedLibrary, content });
+    const paths = built.files.map((file) => file.path);
+    assert.deepEqual(paths.filter((file) => file.startsWith("code/")), ["code/organized.R"]);
+    assert.ok(paths.includes("data/HPV58.nwk"));
+    const yaml = new TextDecoder().decode(built.files.find((file) => file.path === "module.yml")!.bytes);
+    assert.match(yaml, /executionStatus: not_run/u);
+    assert.match(yaml, /executionScope: unknown/u);
   } finally {
     await fs.rm(root, { recursive: true, force: true });
   }

--- a/tests/open-figure-pr-tools.test.ts
+++ b/tests/open-figure-pr-tools.test.ts
@@ -66,6 +66,7 @@ function candidate(): VersionedTemplateCandidate {
     },
     primaryPreview: "visuals/rendered/preview.png",
     canonicalImplementation: { assetPath: "code/render.R", selectedBy: "user" },
+    runtime: {schema:"figure-library.runtime-closure.v1",entrypoint:"code/render.R",inputs:[{codePath:"data/data.csv",assetPath:"references/data.csv",required:true,role:"example_data"}],output:{previewPath:"visuals/rendered/preview.png",mediaType:"image/png"}},
     figureCodeLinks: [
       {
         visualAssetPath: "visuals/rendered/preview.png",
@@ -89,12 +90,14 @@ function candidate(): VersionedTemplateCandidate {
         codeOrigin: "adapted",
         language: "R",
         mediaType: "text/x-r-source",
-        text: "dat <- read.csv('data.csv')\nplot(dat)\n",
+        rights: { license: "MIT", distribution: "public" },
+        text: "dat <- read.csv('data/data.csv')\nplot(dat)\n",
       },
       {
         logicalPath: "references/data.csv",
         role: "reference",
         mediaType: "text/csv",
+        rights: { license: "CC BY 4.0", distribution: "public" },
         text: "group,value\nA,1\nB,2\n",
       },
       {
@@ -108,6 +111,7 @@ function candidate(): VersionedTemplateCandidate {
         role: "visual",
         visualRole: "rendered_output",
         mediaType: "image/png",
+        rights: { license: "CC BY 4.0", distribution: "public" },
         bytes: new Uint8Array(PNG_BYTES),
       },
       {

--- a/tests/publication-export-tools.test.ts
+++ b/tests/publication-export-tools.test.ts
@@ -60,6 +60,7 @@ function safeCandidate(): VersionedTemplateCandidate {
       reason: "The public-safe generated output is the canonical preview; the private source reference remains excluded.",
     },
     canonicalImplementation: { assetPath: "code/render.R", selectedBy: "user" },
+    runtime: {schema:"figure-library.runtime-closure.v1",entrypoint:"code/render.R",inputs:[{codePath:"data/data.csv",assetPath:"references/data.csv",required:true,role:"example_data"}],output:{previewPath:"visuals/rendered/preview.png",mediaType:"image/png"}},
     visualGrouping: {
       visualAssetPaths: ["visuals/source/private-reference.png", "visuals/rendered/preview.png"],
       confirmedBy: "user",
@@ -93,7 +94,7 @@ function safeCandidate(): VersionedTemplateCandidate {
         mediaType: "text/x-r-source",
         text: [
           "args <- commandArgs(trailingOnly = TRUE)",
-          "input_dir <- args[[2]]",
+          "input_dir <- 'data'",
           "output <- args[[4]]",
           "dat <- read.csv(file.path(input_dir, 'data.csv'))",
           "png(output, width = 1, height = 1)",


### PR DESCRIPTION
## 为什么要这样做

本地把绘图模板整理成可公开分发的 Open Figure 模块时，旧逻辑会把多个代码文件映射到同一公开路径，导致发布计划在生成阶段失败。同时，公开模块还可能隐式依赖本机路径、预发布目录，或把内部证据、截图和未明确授权的材料带进公共仓库。这次把运行时输入闭包、可移植路径和公开权益边界一并收紧，并发布对应的 0.6.4 产品版本。

## 修改的内容

### 公开模块导出边界
- 修改方向：修复发布失败，并只导出可公开、可移植的内容
- 内容：
  - 只导出用户选定的主实现代码，避免多个代码文件落到同一公开路径
  - 把公开输入映射为模块内相对路径，不再依赖本机绝对路径
  - 禁止公开模块读取预发布目录或用户主目录作为隐式回退
  - 排除内部证据、回执、原始截图、PDF 和私有参考材料
  - 要求代码与示例数据具备明确的公开再分发声明

### 运行时输入闭包
- 修改方向：让新发布的绘图模板明确声明入口、输入和输出
- 内容：
  - 绑定主实现、每个运行时输入、代码中使用的路径，以及生成预览
  - 发布规划对照不可变版本清单校验闭包
  - 旧版本仍可读；新的公开导出必须提供有效闭包，或走带限制说明的遗留路径

### 产品版本与协议说明
- 修改方向：把产品版本同步到 0.6.4，并记录新的发布约束
- 内容：
  - 同步插件、技能标题和协议文档中的产品版本
  - 补充运行时闭包与公开导出边界的协议说明

### 回归测试
- 修改方向：用自动化测试锁住发布边界
- 内容：
  - 覆盖多个改编代码文件不再发生路径碰撞
  - 确认公开预览字节不被改写
  - 覆盖缺少公开权益声明或缺少运行时闭包时的失败关闭

## 测试步骤

### 测试案例 1：多个改编代码文件的公开导出
1. 准备一个包含主实现、示例脚本和改编源码的已发布条目
2. 生成 Open Figure 公开模块
3. 预期结果：只导出一份主实现代码，不出现公开路径碰撞，预览图像字节保持不变

### 测试案例 2：运行时输入闭包
1. 准备一个没有运行时闭包的新绘图模板
2. 尝试将其晋升为 Local Published
3. 预期结果：发布规划失败，并要求提供明确的运行时闭包

### 测试案例 3：公开权益边界
1. 准备一个示例数据未声明公开再分发权的已发布条目
2. 生成 Open Figure 公开模块
3. 预期结果：导出失败，不会把未授权材料写入公共模块

### 测试案例 4：产品版本同步
1. 运行版本同步检查
2. 检查插件清单、技能标题和协议文档中的产品版本
3. 预期结果：全部显示为 0.6.4

### 测试案例 5：完整测试套件
1. 在该分支运行构建与测试
2. 预期结果：构建通过，全部自动化测试通过