### PR TITLE
fix: 新安装启动时提示绑定绘图仓库和工作区

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Node.js 22+ is required. Register the stdio MCP server as figure-library
 pointing at dist/index.js. For Wisp Science, use npm run package:wisp and
 install the generated plugin. For Cursor, use npm run package:cursor and unzip
 into ~/.cursor/plugins/local/figure-library/. Bind one global Library directory on disk.
-Do not execute user plotting code. First test: source_status, bind if needed,
+Do not execute user plotting code. First test: open or source_status; if
+setup_required, bind the global Library and Local workspace before searching.
 open the workbench, search the local published library.
 Tell me when I need to grant folder access or start a new host session.
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ Community 代码和旧资产保留用于显式兼容访问，但已冻结，且�
 从 https://github.com/xuzhougeng/ScientificFigureLibrary 安装。按
 docs/QUICKSTART.md。需要 Node.js 22+。stdio MCP 名称 figure-library，
 入口 dist/index.js。Wisp Science 用 npm run package:wisp 后安装插件。Cursor 用 npm run package:cursor，解压到 ~/.cursor/plugins/local/figure-library/。
-先绑定一个本机全局 Library 目录。不要运行用户绘图脚本。
+先绑定本机全局绘图仓库（Library）和本地工作区。不要运行用户绘图脚本。
 ```
 
 完整工具契约见 [docs/PROTOCOL.md](docs/PROTOCOL.md)。

--- a/app/main.ts
+++ b/app/main.ts
@@ -105,8 +105,7 @@ const selectedCandidates = new Map<string, Candidate>();
 
 const DEFAULT_TITLE = "选择科学绘图模板";
 const DEFAULT_HINT = "先在这里浏览详情并选择；Agent 会等待你的决定";
-const DEFAULT_EMPTY =
-  "若尚未绑定本机绘图仓库和工作区，请先在对话中指定两个绝对目录。绑定后可上传图片、数据或描述想画的图。";
+const DEFAULT_EMPTY = "请在对话中上传图片或数据，也可以直接描述想画的图。";
 const SETUP_TITLE = "先完成本机绑定";
 const SETUP_HINT = "绑定完成前请先在对话里指定两个绝对目录";
 const SETUP_EMPTY =

--- a/app/main.ts
+++ b/app/main.ts
@@ -103,6 +103,64 @@ const pageCache = new Map<number, SearchResult>();
 const reportedCapabilities = new Set<string>();
 const selectedCandidates = new Map<string, Candidate>();
 
+const DEFAULT_TITLE = "选择科学绘图模板";
+const DEFAULT_HINT = "先在这里浏览详情并选择；Agent 会等待你的决定";
+const DEFAULT_EMPTY =
+  "若尚未绑定本机绘图仓库和工作区，请先在对话中指定两个绝对目录。绑定后可上传图片、数据或描述想画的图。";
+const SETUP_TITLE = "先完成本机绑定";
+const SETUP_HINT = "绑定完成前请先在对话里指定两个绝对目录";
+const SETUP_EMPTY =
+  "新安装需要先指定全局「绘图仓库」和「本地工作区」两个绝对目录。不要使用当前项目目录，除非你明确指定。Agent 会先给出只读 Plan，确认后再写入本机 locator。";
+
+function parseSetup(content: unknown) {
+  if (!content || typeof content !== "object") return undefined;
+  const record = content as Record<string, unknown>;
+  const setup = record.setup;
+  if (setup && typeof setup === "object") {
+    const value = setup as Record<string, unknown>;
+    return {
+      required: value.required === true,
+      missingConfirmations: Array.isArray(value.missingConfirmations)
+        ? value.missingConfirmations.filter((item): item is string => typeof item === "string")
+        : [],
+    };
+  }
+  const envelope = record.envelope;
+  if (envelope && typeof envelope === "object" && (envelope as { code?: string }).code === "setup_required") {
+    const missing = (envelope as { missingConfirmations?: unknown }).missingConfirmations;
+    return {
+      required: true,
+      missingConfirmations: Array.isArray(missing)
+        ? missing.filter((item): item is string => typeof item === "string")
+        : [],
+    };
+  }
+  return undefined;
+}
+
+function applyFirstRunSetup(content: unknown, options: { hasCandidates?: boolean } = {}) {
+  const setup = parseSetup(content);
+  const required = setup?.required === true && !options.hasCandidates;
+  root.dataset.setupRequired = required ? "true" : "false";
+  const title = document.querySelector("#app h1");
+  const hint = document.querySelector(".hint");
+  const emptyText = empty.querySelector("span:last-child");
+  if (required) {
+    if (title) title.textContent = SETUP_TITLE;
+    if (hint) hint.textContent = SETUP_HINT;
+    if (emptyText) emptyText.textContent = SETUP_EMPTY;
+    empty.hidden = false;
+    query.textContent = "等待绑定本机目录";
+    status.textContent = "尚未绑定本机绘图仓库或工作区。请在对话中提供两个绝对目录。";
+    return;
+  }
+  if (!options.hasCandidates) {
+    if (title) title.textContent = DEFAULT_TITLE;
+    if (hint) hint.textContent = DEFAULT_HINT;
+    if (emptyText) emptyText.textContent = DEFAULT_EMPTY;
+  }
+}
+
 function selectedIds() {
   return new Set(selectedCandidates.keys());
 }
@@ -567,6 +625,7 @@ app.ontoolinput = (input) => {
 app.ontoolresult = (result) => {
   const parsed = parseSearchResult(result.structuredContent, result._meta);
   if (parsed) render(parsed);
+  applyFirstRunSetup(result.structuredContent, { hasCandidates: Boolean(parsed?.candidates.length) });
 };
 app.onhostcontextchanged = applyHostContext;
 
@@ -585,7 +644,12 @@ app
     const context = app.getHostContext();
     if (context) applyHostContext(context);
     else refreshDisplayChrome();
-    if (!serverToolsAvailable()) {
+    if (serverToolsAvailable()) {
+      void app
+        .callServerTool({ name: "figure_library_source_status", arguments: {} })
+        .then((result) => applyFirstRunSetup(result.structuredContent))
+        .catch((error: unknown) => console.warn("first-run status failed", error));
+    } else {
       status.textContent = updateModelContextAvailable()
         ? "当前 Host 未授权 serverTools；仍可查看当前页详情并选择一个候选交给 Agent 审核。"
         : "当前 Host 未授权 serverTools 或 updateModelContext；只能查看已返回的基础详情。";

--- a/app/mcp-app.html
+++ b/app/mcp-app.html
@@ -29,7 +29,7 @@
 
       <section id="empty" class="empty" aria-live="polite">
         <span id="empty-icon" class="state-icon" aria-hidden="true"></span>
-        <span>请在对话中上传图片或数据，也可以直接描述想画的图。</span>
+        <span>若尚未绑定本机绘图仓库和工作区，请先在对话中指定两个绝对目录。绑定后可上传图片、数据或描述想画的图。</span>
       </section>
       <section id="cards" class="cards" aria-label="Scientific figure template candidates"></section>
       <section id="plot-set-bar" class="plot-set-bar" aria-label="多选绘图模板">

--- a/app/mcp-app.html
+++ b/app/mcp-app.html
@@ -29,7 +29,7 @@
 
       <section id="empty" class="empty" aria-live="polite">
         <span id="empty-icon" class="state-icon" aria-hidden="true"></span>
-        <span>若尚未绑定本机绘图仓库和工作区，请先在对话中指定两个绝对目录。绑定后可上传图片、数据或描述想画的图。</span>
+        <span>请在对话中上传图片或数据，也可以直接描述想画的图。</span>
       </section>
       <section id="cards" class="cards" aria-label="Scientific figure template candidates"></section>
       <section id="plot-set-bar" class="plot-set-bar" aria-label="多选绘图模板">

--- a/app/styles.css
+++ b/app/styles.css
@@ -353,6 +353,11 @@ button[aria-pressed="true"] {
   overflow-wrap: anywhere;
 }
 
+#app[data-setup-required="true"] .empty {
+  border-color: var(--color-border-primary, #8aa193);
+  color: var(--color-text-primary, #1f2a24);
+}
+
 footer {
   display: flex;
   align-items: flex-start;

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -247,9 +247,12 @@ content. The root marker is `figure-library.root.v1`, storage layout
 
 If neither a locator nor `FIGURE_LIBRARY_DIR` exists, legacy
 `~/.figure-library` may be inspected read-only. Writes fail closed until the
-user explicitly binds a global Library. `figure_library_source_status` reports
-the effective root, source, locator, `libraryId`, write state, counts, lock
-state, and FigureYa source-pack state.
+user explicitly binds a global Library. `figure_library_source_status` and
+`figure_library_open` report `CODE: setup_required` when the global Library
+or Local workspace is unbound. The App empty state and Skill then ask for the
+missing absolute directories instead of a plotting query. `figure_library_source_status`
+also reports the effective root, source, locator, `libraryId`, write state,
+counts, lock state, and FigureYa source-pack state.
 
 ## Direct image/code intake
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -60,15 +60,19 @@ is the local plugin path.
 
 ## First session
 
-1. Call `figure_library_source_status`. If writes are off, bind a global
-   Library with `figure_library_plan_bind_global` then
-   `figure_library_apply_bind_global` after the user confirms the absolute path.
-2. Import a figure/code pair if the local library is empty, review it, and
+1. Call `figure_library_open` or `figure_library_source_status`. A new install
+   returns `setup_required` until both roots exist.
+2. If setup is required, ask for two absolute directories: the global Library
+   (绘图仓库) and the Local workspace (本地工作区). Do not use the current
+   project folder unless the user names it. Plan/Apply
+   `figure_library_plan_bind_global` and `figure_library_plan_bind_workspace`
+   after the user confirms each path.
+3. Import a figure/code pair if the local library is empty, review it, and
    publish a Release.
-3. Call `figure_library_open`, or `figure_library_search` against Local
-   Published.
-4. Wait for the user to confirm one exact card.
-5. Materialize only after a preview receipt: `figure_library_plan_materialize`
+4. After both binds succeed, call `figure_library_open` or
+   `figure_library_search` against Local Published.
+5. Wait for the user to confirm one exact card.
+6. Materialize only after a preview receipt: `figure_library_plan_materialize`
    then `figure_library_apply_materialize`.
 
 Full contract: [PROTOCOL.md](PROTOCOL.md).

--- a/skills/figure-library/SKILL.md
+++ b/skills/figure-library/SKILL.md
@@ -78,6 +78,8 @@ Read these fields once and follow `NEXT_ACTION`:
 - `stop_other_writers`: ask the user to stop every Wisp, Codex, Claude, and
   other writer. Never steal a lock automatically.
 - `rebind_library`: inspect status and request an explicit global binding.
+- `rebind_workspace`: inspect status and request an explicit Local workspace
+  binding.
 - `none`: stop; do not make another equivalent call.
 
 Never repeat an identical failed, blocked, not-found, stale, or expired call.
@@ -98,10 +100,23 @@ for user-visible App preview.
 
 ## 1. Inspect or bind the global Library
 
+On first install, plugin startup, or whenever the user only asks to open SFL,
+call `figure_library_open` or `figure_library_source_status` before searching.
+If `CODE` is `setup_required`, stop. Do not invent a plotting query. Ask for
+every listed `MISSING_CONFIRMATIONS` absolute directory:
+
+- `globalLibraryDirectory`: one cross-project Published Library root
+- `localWorkspaceDirectory`: one machine-local inbox/drafts/gallery workspace
+
+Never infer either path from the current project folder unless the user names
+that folder. Plan each bind, show the exact path, then Apply only after
+approval. Later MCP starts reuse those locators silently.
+
 Call `figure_library_source_status` when the effective Library is unknown. It
 reports the global root/source, locator, `libraryId`, write status, lifecycle
 counts, write lock, Local Published provider, FigureYa provider, and Local
-workspace confirmation.
+workspace confirmation. New installs return `setup_required` until both roots
+are bound.
 
 This machine has two roots. They are cross-project and are not inferred from
 the current Wisp cwd:
@@ -313,7 +328,8 @@ the Published pointer backward directly.
 ## 4. Search the dynamic Provider set
 
 If the user only asks to open the workbench, call `figure_library_open`; do not
-invent a generic query. Otherwise inspect the request first:
+invent a generic query. If it returns `setup_required`, bind the missing
+directories first. Otherwise inspect the request first:
 
 - image: view it before searching;
 - data: profile shape, columns/types, semantic roles, and missingness locally;

--- a/src/first-run-setup.ts
+++ b/src/first-run-setup.ts
@@ -1,0 +1,80 @@
+import type { ToolNextAction } from "./library-binding-tools.ts";
+import type { LibraryRuntimeSnapshot } from "./library-runtime.ts";
+import type { WorkspaceRuntimeSnapshot } from "./workspace-runtime.ts";
+
+export const SETUP_MISSING_LIBRARY = "globalLibraryDirectory" as const;
+export const SETUP_MISSING_WORKSPACE = "localWorkspaceDirectory" as const;
+
+export type FirstRunMissingConfirmation =
+  | typeof SETUP_MISSING_LIBRARY
+  | typeof SETUP_MISSING_WORKSPACE;
+
+export interface FirstRunSetupStatus {
+  required: boolean;
+  libraryBound: boolean;
+  workspaceBound: boolean;
+  librarySource: LibraryRuntimeSnapshot["directorySource"];
+  workspaceSource: WorkspaceRuntimeSnapshot["directorySource"];
+  writesEnabled: boolean;
+  missingConfirmations: FirstRunMissingConfirmation[];
+  code: "setup_required" | "library_ready";
+  nextAction: Extract<ToolNextAction, "none" | "ask_user" | "rebind_library" | "rebind_workspace">;
+  summary: string;
+}
+
+export function libraryIsBoundForWrites(
+  library: Pick<LibraryRuntimeSnapshot, "directorySource" | "writesEnabled">,
+) {
+  return library.writesEnabled && library.directorySource !== "legacy-default";
+}
+
+export function firstRunSetupStatus(input: {
+  library: Pick<LibraryRuntimeSnapshot, "directorySource" | "writesEnabled">;
+  workspace: Pick<WorkspaceRuntimeSnapshot, "confirmed" | "directorySource">;
+}): FirstRunSetupStatus {
+  const libraryBound = libraryIsBoundForWrites(input.library);
+  const workspaceBound = input.workspace.confirmed === true;
+  const missingConfirmations: FirstRunMissingConfirmation[] = [];
+  if (!libraryBound) missingConfirmations.push(SETUP_MISSING_LIBRARY);
+  if (!workspaceBound) missingConfirmations.push(SETUP_MISSING_WORKSPACE);
+  const required = missingConfirmations.length > 0;
+  let nextAction: FirstRunSetupStatus["nextAction"] = "none";
+  if (!libraryBound && !workspaceBound) nextAction = "ask_user";
+  else if (!libraryBound) nextAction = "rebind_library";
+  else if (!workspaceBound) nextAction = "rebind_workspace";
+  return {
+    required,
+    libraryBound,
+    workspaceBound,
+    librarySource: input.library.directorySource,
+    workspaceSource: input.workspace.directorySource,
+    writesEnabled: input.library.writesEnabled,
+    missingConfirmations,
+    code: required ? "setup_required" : "library_ready",
+    nextAction,
+    summary: required
+      ? "This install has not finished first-run setup. Ask for the missing absolute directories, then Plan/Apply bind. Do not infer the current project folder."
+      : "Global Library and Local workspace are bound for this machine.",
+  };
+}
+
+export function firstRunSetupPayload(status: FirstRunSetupStatus) {
+  return {
+    required: status.required,
+    libraryBound: status.libraryBound,
+    workspaceBound: status.workspaceBound,
+    librarySource: status.librarySource,
+    workspaceSource: status.workspaceSource,
+    writesEnabled: status.writesEnabled,
+    missingConfirmations: status.missingConfirmations,
+  };
+}
+
+export function firstRunSetupLines(status: FirstRunSetupStatus) {
+  return [
+    `SETUP_REQUIRED: ${status.required}`,
+    `LIBRARY_BOUND: ${status.libraryBound}`,
+    `WORKSPACE_BOUND: ${status.workspaceBound}`,
+    `MISSING_CONFIRMATIONS: ${status.missingConfirmations.join(",") || "none"}`,
+  ];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import {
 } from "./library-binding-tools.ts";
 import { LibraryRuntime, readLibraryRootMarker } from "./library-runtime.ts";
 import { WorkspaceRuntime } from "./workspace-runtime.ts";
+import { firstRunSetupLines, firstRunSetupPayload, firstRunSetupStatus } from "./first-run-setup.ts";
 import { registerLifecycleTools } from "./lifecycle-tools.ts";
 import { registerMaterializationTools } from "./materialization-tools.ts";
 import { registerGitHubPublicationTools } from "./github-publication-tools.ts";
@@ -153,6 +154,7 @@ function outcome(
   code: string,
   summary: string,
   nextAction: ToolOutcomeEnvelope["nextAction"] = "none",
+  missingConfirmations?: string[],
 ): ToolOutcomeEnvelope {
   return {
     schema: "figure-library.tool-outcome.v1",
@@ -162,6 +164,7 @@ function outcome(
     code,
     summary,
     nextAction,
+    ...(missingConfirmations?.length ? { missingConfirmations } : {}),
   };
 }
 
@@ -181,6 +184,9 @@ function terminal(
           "RETRY_SAME_CALL: false",
           `CODE: ${envelope.code}`,
           `NEXT_ACTION: ${envelope.nextAction}`,
+          ...(envelope.missingConfirmations?.length
+            ? [`MISSING_CONFIRMATIONS: ${envelope.missingConfirmations.join(",")}`]
+            : []),
           envelope.summary,
           ...lines,
         ].join("\n"),
@@ -576,7 +582,7 @@ export async function createServer(options: {
     {
       title: "Open Scientific Figure Library",
       description:
-        "Open the read-only candidate workbench. Ask for an uploaded reference, data profile, or plotting goal before searching.",
+        "Open the read-only candidate workbench. New installs return setup_required until the global Library and Local workspace are bound; otherwise ask for an uploaded reference, data profile, or plotting goal before searching.",
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -587,28 +593,44 @@ export async function createServer(options: {
       _meta: { ui: { resourceUri: RESOURCE_URI, visibility: ["model"] } },
     },
     async (): Promise<CallToolResult> => {
-      const responseEnvelope = outcome(
-        "ok",
-        "library_ready",
-        `Scientific Figure Library ${VERSION} is ready. Standard core uses direct user-confirmed image/code intake; Web Capture and project pins are not registered. Ask for a plotting goal before searching.`,
-        "ask_user",
+      const context = await currentLibraries();
+      const workspace = await workspaceRuntime.current();
+      const setup = firstRunSetupStatus({ library: context.snapshot, workspace });
+      const responseEnvelope = setup.required
+        ? outcome(
+            "ok",
+            setup.code,
+            setup.summary,
+            "ask_user",
+            setup.missingConfirmations,
+          )
+        : outcome(
+            "ok",
+            "library_ready",
+            `Scientific Figure Library ${VERSION} is ready. Standard core uses direct user-confirmed image/code intake; Web Capture and project pins are not registered. Ask for a plotting goal before searching.`,
+            "ask_user",
+          );
+      return terminal(
+        responseEnvelope,
+        {
+          query: setup.required ? "等待绑定本机目录" : "等待绘图目标",
+          libraryVersion: VERSION,
+          intentFamilies: [],
+          reviewRequired: false,
+          materializationProtocolVersion: MATERIALIZATION_PROTOCOL_VERSION,
+          resultSetId: null,
+          pagination: { total: 0, pageIndex: 0, pageSize: 6, hasMore: false, nextCursor: null },
+          sources: registry.list().map(({ providerId, sourceLabel }) => ({
+            providerId,
+            sourceLabel,
+            matched: 0,
+          })),
+          candidates: [],
+          diagnosticsDegraded: diagnostics.degraded,
+          setup: firstRunSetupPayload(setup),
+        },
+        firstRunSetupLines(setup),
       );
-      return terminal(responseEnvelope, {
-        query: "等待绘图目标",
-        libraryVersion: VERSION,
-        intentFamilies: [],
-        reviewRequired: false,
-        materializationProtocolVersion: MATERIALIZATION_PROTOCOL_VERSION,
-        resultSetId: null,
-        pagination: { total: 0, pageIndex: 0, pageSize: 6, hasMore: false, nextCursor: null },
-        sources: registry.list().map(({ providerId, sourceLabel }) => ({
-          providerId,
-          sourceLabel,
-          matched: 0,
-        })),
-        candidates: [],
-        diagnosticsDegraded: diagnostics.degraded,
-      });
     },
   );
 
@@ -1710,7 +1732,7 @@ export async function createServer(options: {
     {
       title: "Inspect global Library and Provider status",
       description:
-        "Return complete text and structured status for the global portable Library, immutable lifecycle, write lock, and every registered Local, Community, FigureYa, or personal Provider. Community is reported as frozen and excluded from default search. Capture/project-pin status is intentionally absent.",
+        "Return complete text and structured status for the global portable Library, immutable lifecycle, write lock, and every registered Local, Community, FigureYa, or personal Provider. Community is reported as frozen and excluded from default search. Capture/project-pin status is intentionally absent. New installs report setup_required until both the global Library and Local workspace are bound.",
       inputSchema: SourceStatusInput.shape,
       annotations: {
         readOnlyHint: true,
@@ -1718,6 +1740,7 @@ export async function createServer(options: {
         idempotentHint: true,
         openWorldHint: false,
       },
+      _meta: { ui: { visibility: ["model", "app"] } },
     },
     async ({ sourcePackDir, moduleSourcePackDir }): Promise<CallToolResult> => {
       try {
@@ -1812,9 +1835,17 @@ export async function createServer(options: {
             },
           },
         };
+        const setup = firstRunSetupStatus({ library: context.snapshot, workspace });
+        const structuredWithSetup = { ...structured, setup: firstRunSetupPayload(setup) };
         return terminal(
-          outcome("ok", "source_status_ready", "Complete source status follows; no files were written."),
-          structured,
+          outcome(
+            "ok",
+            setup.required ? setup.code : "source_status_ready",
+            setup.required ? setup.summary : "Complete source status follows; no files were written.",
+            setup.required ? setup.nextAction : "none",
+            setup.required ? setup.missingConfirmations : undefined,
+          ),
+          structuredWithSetup,
           [
             `SERVER_VERSION: ${VERSION}`,
             `LIBRARY_ROOT: ${context.snapshot.root}`,
@@ -1874,6 +1905,7 @@ export async function createServer(options: {
             `WORKSPACE_CONFIRMED: ${workspace.confirmed}`,
             `WORKSPACE_KIND: ${workspace.inspection?.kind ?? "unbound"}`,
             `WORKSPACE_LOCATOR_PATH: ${workspace.locatorPath}`,
+            ...firstRunSetupLines(setup),
           ],
         );
       } catch (error) {

--- a/tests/first-run-setup.test.ts
+++ b/tests/first-run-setup.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { firstRunSetupStatus } from "../src/first-run-setup.ts";
+
+test("a brand-new install requires both Library and workspace directories", () => {
+  const status = firstRunSetupStatus({
+    library: { directorySource: "legacy-default", writesEnabled: false },
+    workspace: { confirmed: false, directorySource: "unbound" },
+  });
+  assert.equal(status.required, true);
+  assert.equal(status.code, "setup_required");
+  assert.equal(status.nextAction, "ask_user");
+  assert.deepEqual(status.missingConfirmations, [
+    "globalLibraryDirectory",
+    "localWorkspaceDirectory",
+  ]);
+});
+
+test("an explicit Library bind still requires the Local workspace", () => {
+  const status = firstRunSetupStatus({
+    library: { directorySource: "locator", writesEnabled: true },
+    workspace: { confirmed: false, directorySource: "unbound" },
+  });
+  assert.equal(status.required, true);
+  assert.equal(status.nextAction, "rebind_workspace");
+  assert.deepEqual(status.missingConfirmations, ["localWorkspaceDirectory"]);
+});
+
+test("a confirmed workspace still requires an explicit writable Library", () => {
+  const status = firstRunSetupStatus({
+    library: { directorySource: "legacy-default", writesEnabled: false },
+    workspace: { confirmed: true, directorySource: "locator" },
+  });
+  assert.equal(status.required, true);
+  assert.equal(status.nextAction, "rebind_library");
+  assert.deepEqual(status.missingConfirmations, ["globalLibraryDirectory"]);
+});
+
+test("locator or env-bound Library plus confirmed workspace is ready", () => {
+  for (const directorySource of ["locator", "FIGURE_LIBRARY_DIR", "argument"] as const) {
+    const status = firstRunSetupStatus({
+      library: { directorySource, writesEnabled: true },
+      workspace: { confirmed: true, directorySource: "locator" },
+    });
+    assert.equal(status.required, false, directorySource);
+    assert.equal(status.code, "library_ready", directorySource);
+    assert.equal(status.nextAction, "none", directorySource);
+    assert.deepEqual(status.missingConfirmations, []);
+  }
+});


### PR DESCRIPTION
## 🎯 为什么要这样做

新安装用户打开插件时，工作台会直接说可以上传图片或描述想画的图，Agent 也会把工作台当成已经就绪。实际上本机全局绘图仓库仍落在只读默认目录，本地工作区也尚未确认。用户不会被要求完成这两项绑定。

## ⚠️ 修改的内容

### 首次启动绑定检查
- **修改方向**：把尚未绑定从静默只读状态改成明确的终端结果
- **内容**：
  - 打开工作台或查看来源状态时，若全局绘图仓库或本地工作区未绑定，返回需要设置，而不是已经就绪
  - 明确列出缺少的绝对目录：全局绘图仓库、本地工作区
  - 已绑定的机器保持原来的就绪路径，继续询问绘图目标

### 工作台提示
- **修改方向**：空状态从直接开始搜图改为先完成本机绑定
- **内容**：
  - 启动后若宿主允许，主动检查绑定状态
  - 未绑定时标题和空状态改为先指定两个绝对目录
  - 有搜索结果后仍展示候选，不阻断浏览

### 代理与文档
- **修改方向**：首次会话先绑定，再搜索
- **内容**：
  - Skill 要求看到需要设置后停止编造检索词
  - 首次会话说明改为同时绑定绘图仓库和工作区
  - 增加未绑定、只缺工作区、只缺绘图仓库、两者都已绑定的判定测试

## 🧪 测试步骤

### 测试案例 1：全新安装打开工作台
1. 在没有本机 locator 和目录覆盖的环境启动插件
2. 打开工作台
3. **预期结果**：结果码为需要设置，并同时列出全局绘图仓库和本地工作区

### 测试案例 2：已绑定机器打开工作台
1. 使用已经绑定的全局绘图仓库和本地工作区
2. 打开工作台
3. **预期结果**：结果码为已经就绪，并继续询问绘图目标

### 测试案例 3：工作台空状态文案
1. 以未绑定状态打开工作台界面
2. 查看标题和空状态
3. **预期结果**：提示先指定两个绝对目录，而不是直接上传图片或描述想画的图

### 测试案例 4：绑定判定
1. 分别构造两者都缺、只缺工作区、只缺绘图仓库、两者都已绑定
2. 运行绑定判定测试
3. **预期结果**：四类情况分别给出需要设置、重绑工作区、重绑绘图仓库、已经就绪