### PR TITLE
feat: emit verified update feed for independently installed Wisp plugins

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -44,6 +44,9 @@ npm run package:wisp
 Install the generated ZIP from `release/` in **Settings → Plugins**, enable it
 for the project, and start a new session.
 
+For maintainers, packaging also emits a [Wisp update feed](WISP_UPDATES.md).
+This is a release-side prerequisite; current Wisp installation steps still apply.
+
 ## Cursor
 
 ```bash

--- a/docs/WISP_UPDATES.md
+++ b/docs/WISP_UPDATES.md
@@ -1,0 +1,50 @@
+# Wisp managed updates (release-side contract)
+
+This feed is a prerequisite for a future Wisp integration. Current Wisp builds
+do not consume it. The MCP server does not install or update itself.
+
+## Publish the feed
+
+`npm run package:wisp` and `npm run package:plugins` generate
+`release/scientific-figure-library-wisp-update.json` alongside the Wisp ZIP and
+SHA-256 sidecar. The feed is committed in the same rollback-protected local
+transaction, after the archive checks and packaged MCP smoke test pass.
+The all-host packager rechecks the feed against the staged archive.
+
+Upload all three files to the matching stable GitHub Release `v<version>` before
+publishing that release. The scripts do not upload assets. The Wisp feed currently
+requires a stable version; prerelease packaging through these entrypoints fails.
+
+Discovery URL:
+https://github.com/xuzhougeng/ScientificFigureLibrary/releases/latest/download/scientific-figure-library-wisp-update.json
+
+Schema `figure-library.wisp-update.v1` contains `plugin_id`, `version`, `channel`,
+`repository`, `release_url`, `requirements.plugin_schema`, `requirements.node`,
+and `asset` (`name`, version-pinned `url`, `sha256`, byte `size`). Node requirements
+come from package.json; Node is not bundled. No untested minimum Wisp version is
+claimed. SHA-256 detects corruption, not an independent publisher signature.
+
+## Wisp implementation still needed
+
+1. Ship a tested package and automatically deploy it to the managed plugin
+   directory, without overwriting a newer installed version. Ask the user for
+   Library and workspace roots on first use; never assume the current project.
+2. Check the trusted feed in the background at startup. Respect disabled checks
+   and skipped versions. Missing feeds, network failures, or invalid metadata
+   leave the current installation usable and do not block startup.
+3. Show an update card with current/new versions, release notes, Update, Later,
+   and Skip. Wisp handles the download after confirmation; users do not select
+   ZIPs or enter checksums.
+4. Validate feed schema, repository, plugin ID, runtime requirements and the
+   version-pinned asset origin/path. Enforce HTTPS including redirects and bounded
+   downloads. Check size, digest and extracted plugin identity/version before
+   using Wisp's staged installer.
+5. Serialize installs and defer replacement while the plugin is in use. Preserve
+   bindings, user data and project enabled state. Keep the previous package until
+   a fresh MCP initialize/tools-list and `figure_library_source_status` succeed;
+   restore it on failure. `setup_required` on first use is a setup prompt, not an
+   installation failure.
+
+Wisp Browser Bridge provides a UI/lifecycle precedent, but compares the connected
+extension with Wisp's bundled copy. GitHub discovery is additional work, and its
+browser reload commands cannot restart this stdio MCP server.

--- a/scripts/package-plugins.mjs
+++ b/scripts/package-plugins.mjs
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { unzipSync } from "fflate";
+import { buildWispUpdateManifest, WISP_UPDATE_MANIFEST } from "./wisp-update-manifest.mjs";
 import {
   assertFinalCommunitySnapshot,
   auditPackageContents,
@@ -45,7 +46,7 @@ try {
     if (stderr.trim()) console.error(stderr.trim());
   }
 
-  const expected = [];
+  const expected = [WISP_UPDATE_MANIFEST];
   for (const host of ["wisp", "codex", "claude", "cursor"]) {
     const zipName = `scientific-figure-library-${host}-${packageJson.version}.zip`;
     expected.push(zipName, `${zipName}.sha256`);
@@ -65,9 +66,20 @@ try {
     const sidecar = Buffer.from(artifacts.get(`${zipName}.sha256`)).toString("utf8").trim();
     if (sidecar !== `${digest}  ${zipName}`) throw new Error(`${zipName} staged SHA-256 sidecar is invalid`);
     auditPackageContents(unzipSync(bytes), { label: zipName, repositoryRoot: root });
+    if (host === "wisp") {
+      const expectedManifest = buildWispUpdateManifest({
+        version: packageJson.version,
+        nodeEngine: packageJson.engines.node,
+        candidate: { baseName: zipName, zip: bytes, sha256: digest, unpacked: unzipSync(bytes) },
+      });
+      const observedManifest = JSON.parse(Buffer.from(artifacts.get(WISP_UPDATE_MANIFEST)).toString("utf8"));
+      if (JSON.stringify(observedManifest) !== JSON.stringify(expectedManifest)) {
+        throw new Error("staged Wisp update manifest does not match the verified ZIP");
+      }
+    }
   }
   await publishReleaseArtifacts(root, artifacts);
-  console.log(`Published all ${observed.length} verified plugin ZIP/SHA artifacts as one rollback-protected transaction.`);
+  console.log(`Published all ${observed.length} verified plugin release artifacts as one rollback-protected transaction.`);
 } finally {
   await fs.rm(temporary, { recursive: true, force: true });
 }

--- a/scripts/package-wisp.mjs
+++ b/scripts/package-wisp.mjs
@@ -13,6 +13,7 @@ import {
   writeVerifiedZip,
 } from "./plugin-package-lib.mjs";
 import path from "node:path";
+import { buildWispUpdateManifest, WISP_UPDATE_MANIFEST } from "./wisp-update-manifest.mjs";
 
 await assertPluginReleaseReady();
 
@@ -46,7 +47,14 @@ const smoke = await smokePackagedPlugin({
   unpacked,
   version: packageJson.version,
 });
-const outputPath = await publishVerifiedZip(candidate);
+const updateManifest = buildWispUpdateManifest({
+  version: packageJson.version,
+  nodeEngine: packageJson.engines.node,
+  candidate,
+});
+const outputPath = await publishVerifiedZip(candidate, new Map([
+  [WISP_UPDATE_MANIFEST, new TextEncoder().encode(`${JSON.stringify(updateManifest, null, 2)}\n`)],
+]));
 console.log(
   `${outputPath}\nSHA-256 ${sha256}\nVerified ${actualFiles.length} packaged files; foreign-cwd initialize/tools-list exposed ${smoke.toolCount} tools`,
 );

--- a/scripts/plugin-package-lib.mjs
+++ b/scripts/plugin-package-lib.mjs
@@ -268,17 +268,22 @@ export async function writeVerifiedZip(archive, baseName) {
   };
 }
 
-export async function publishVerifiedZip(candidate) {
+export async function publishVerifiedZip(candidate, extraArtifacts = new Map()) {
   const checksumName = `${candidate.baseName}.sha256`;
+  if (extraArtifacts.has(candidate.baseName) || extraArtifacts.has(checksumName)) {
+    throw new Error("extra artifacts must not replace the verified ZIP or checksum");
+  }
   const stagingDirectory = process.env.SFL_RELEASE_STAGING_DIR;
   const publish = stagingDirectory
     ? publishArtifactsToDirectory(stagingDirectory, new Map([
         [candidate.baseName, candidate.zip],
         [checksumName, strToU8(`${candidate.sha256}  ${candidate.baseName}\n`)],
+        ...extraArtifacts,
       ]))
     : publishReleaseArtifacts(root, new Map([
         [candidate.baseName, candidate.zip],
         [checksumName, strToU8(`${candidate.sha256}  ${candidate.baseName}\n`)],
+        ...extraArtifacts,
       ]));
   await publish;
   const releaseDirectory = stagingDirectory

--- a/scripts/wisp-update-manifest.mjs
+++ b/scripts/wisp-update-manifest.mjs
@@ -1,0 +1,39 @@
+import { createHash } from "node:crypto";
+
+export const WISP_UPDATE_MANIFEST = "scientific-figure-library-wisp-update.json";
+const repository = "xuzhougeng/ScientificFigureLibrary";
+
+// Release metadata describes the exact verified ZIP, never a moving download URL.
+export function buildWispUpdateManifest({ version, nodeEngine, candidate }) {
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
+    throw new Error("Wisp stable update feed requires a stable semantic version");
+  }
+  const name = `scientific-figure-library-wisp-${version}.zip`;
+  const digest = createHash("sha256").update(candidate.zip).digest("hex");
+  if (candidate.baseName !== name || candidate.sha256 !== digest) {
+    throw new Error("Wisp update ZIP name or digest does not match the candidate");
+  }
+  const manifest = JSON.parse(new TextDecoder().decode(candidate.unpacked[".wisp-plugin/plugin.json"]));
+  if (manifest.id !== "figure-library" || manifest.version !== version || manifest.schema !== "wisp.plugin.v1") {
+    throw new Error("Wisp update manifest identity/version/schema mismatch");
+  }
+  if (typeof nodeEngine !== "string" || !nodeEngine.trim()) {
+    throw new Error("Wisp update manifest requires the package Node engine");
+  }
+  const releaseUrl = `https://github.com/${repository}/releases/tag/v${version}`;
+  return {
+    schema: "figure-library.wisp-update.v1",
+    plugin_id: manifest.id,
+    version,
+    channel: "stable",
+    repository,
+    release_url: releaseUrl,
+    requirements: { plugin_schema: manifest.schema, node: nodeEngine },
+    asset: {
+      name,
+      url: `https://github.com/${repository}/releases/download/v${version}/${name}`,
+      sha256: digest,
+      size: candidate.zip.byteLength,
+    },
+  };
+}

--- a/tests/wisp-update-manifest.test.ts
+++ b/tests/wisp-update-manifest.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import { zipSync } from "fflate";
+// @ts-expect-error -- release scripts are plain JavaScript without declarations.
+import { buildWispUpdateManifest } from "../scripts/wisp-update-manifest.mjs";
+
+function fixture() {
+  const unpacked = {
+    ".wisp-plugin/plugin.json": new TextEncoder().encode(JSON.stringify({
+      id: "figure-library", version: "1.2.3", schema: "wisp.plugin.v1",
+    })),
+  };
+  const zip = zipSync(unpacked);
+  return { version: "1.2.3", nodeEngine: ">=22", candidate: {
+    baseName: "scientific-figure-library-wisp-1.2.3.zip", unpacked, zip,
+    sha256: createHash("sha256").update(zip).digest("hex"),
+  } };
+}
+
+test("feed pins the verified Wisp ZIP and runtime", () => {
+  const input = fixture();
+  const manifest = buildWispUpdateManifest(input);
+  assert.equal(manifest.plugin_id, "figure-library");
+  assert.equal(manifest.asset.url, "https://github.com/xuzhougeng/ScientificFigureLibrary/releases/download/v1.2.3/scientific-figure-library-wisp-1.2.3.zip");
+  assert.equal(manifest.asset.sha256, input.candidate.sha256);
+  assert.equal(manifest.asset.size, input.candidate.zip.byteLength);
+  assert.deepEqual(manifest.requirements, { plugin_schema: "wisp.plugin.v1", node: ">=22" });
+});
+
+test("reject mismatched package and unstable release metadata", () => {
+  for (const mutate of [
+    (x: any) => { x.candidate.baseName = "cursor.zip"; },
+    (x: any) => { x.candidate.sha256 = "0".repeat(64); },
+    (x: any) => { x.candidate.zip = new Uint8Array([1]); },
+    (x: any) => { x.version = "1.2.3-beta.1"; },
+    (x: any) => { x.version = "../1.2.3"; },
+    (x: any) => { x.nodeEngine = ""; },
+    (x: any) => { x.candidate.unpacked[".wisp-plugin/plugin.json"] = new TextEncoder().encode('{"id":"other"}'); },
+  ]) {
+    const input = fixture();
+    mutate(input);
+    assert.throws(() => buildWispUpdateManifest(input));
+  }
+});


### PR DESCRIPTION
## Problem and result
Wisp users currently have to locate a Scientific Figure Library release ZIP and install it themselves. A Browser Bridge-style update card needs deterministic release metadata so the host can download and verify the correct package after the user clicks Update.

This PR adds the **release-side prerequisite**, not the Wisp UI or an MCP self-updater. Both Wisp-only and all-host packaging now emit `scientific-figure-library-wisp-update.json` with plugin ID, stable version, pinned asset URL, size, SHA-256 and runtime/schema requirements.

Closes #13. Host integration is tracked in https://github.com/xuzhougeng/wisp-science/issues/1219.

## Changes
- Build the feed from the verified Wisp package, rejecting mismatched identity, version, filename and digest.
- Publish the feed with the ZIP/checksum in the existing rollback-protected local transaction, after packaged MCP smoke checks.
- Revalidate the feed against staged ZIP bytes in the all-host release entrypoint.
- Add offline tests and publishing/host-consumer documentation linked from QUICKSTART.

## Validation
- New feed tests: 2 passed.
- `npm run package:plugins`: passed; all four host archives passed foreign-directory initialize/tools-list smoke (53 tools each), and nine artifacts were published locally.
- `npm run test:smoke`: passed, including build/typecheck.
- Final `npm test`: 286/287 passed. The remaining existing backup test fails on this Windows host with EPERM when creating a directory symlink (`tests/portable-bundles.test.ts`). No test was disabled. Initial checkout CRLF conversion also broke byte-locked asset tests; restoring tracked LF bytes resolved those failures without changing their source.
- `git diff --check`: passed.

## Manual publishing check and limitations
Run `npm run package:wisp`, inspect the feed against the ZIP/sidecar, then upload all three artifacts to matching stable release `v<version>` before publishing. This PR does not upload assets, publish a release, or change the current release.

The feed currently accepts stable x.y.z versions only; prerelease Wisp packaging is rejected. SHA-256 is integrity verification, not a publisher signature. Node is not bundled, and no untested minimum Wisp version is claimed.

Wisp still needs an update-page link and user-triggered update action for an independently installed SFL plugin, on-demand feed lookup, automatic download/install, active-session coordination, and MCP verification/rollback. SFL remains optional and is not bundled with Wisp. Initial automatic deployment and startup polling are outside this scope. The flow is: installed drawing plugin → update entry → click Update → Wisp downloads and installs the Wisp-specific plugin package.
