### PR TITLE
docs: clarify optional installation and on-demand Wisp plugin updates

### DIFF
--- a/docs/WISP_UPDATES.md
+++ b/docs/WISP_UPDATES.md
@@ -1,7 +1,21 @@
-# Wisp managed updates (release-side contract)
+# Wisp on-demand plugin updates (release-side contract)
 
-This feed is a prerequisite for a future Wisp integration. Current Wisp builds
-do not consume it. The MCP server does not install or update itself.
+Scientific Figure Library is an optional, separately installed plugin. Wisp does
+not bundle SFL, its catalogs, or a copy for automatic initial deployment. This
+keeps the host lightweight. Initial installation follows QUICKSTART.
+
+After installation, the plugin entry should expose a link to SFL's update page:
+https://github.com/xuzhougeng/ScientificFigureLibrary/releases
+
+The intended flow is: open the installed plugin's update entry, choose Update,
+and let Wisp download, verify and install the available **Wisp plugin** package.
+The user does not manually download another ZIP or enter a checksum. Opening
+the release-page link alone is informational and does not authorize installation.
+Startup polling or bundled deployment is not required for this flow.
+
+The feed below is a prerequisite for that future Wisp integration. It provides
+a machine-readable counterpart to the release page. It does not add the update
+entry or installer UI, and the MCP server does not install or update itself.
 
 ## Publish the feed
 
@@ -15,7 +29,7 @@ Upload all three files to the matching stable GitHub Release `v<version>` before
 publishing that release. The scripts do not upload assets. The Wisp feed currently
 requires a stable version; prerelease packaging through these entrypoints fails.
 
-Discovery URL:
+Discovery URL (read when the installed plugin's update flow is invoked):
 https://github.com/xuzhougeng/ScientificFigureLibrary/releases/latest/download/scientific-figure-library-wisp-update.json
 
 Schema `figure-library.wisp-update.v1` contains `plugin_id`, `version`, `channel`,
@@ -26,25 +40,22 @@ claimed. SHA-256 detects corruption, not an independent publisher signature.
 
 ## Wisp implementation still needed
 
-1. Ship a tested package and automatically deploy it to the managed plugin
-   directory, without overwriting a newer installed version. Ask the user for
-   Library and workspace roots on first use; never assume the current project.
-2. Check the trusted feed in the background at startup. Respect disabled checks
-   and skipped versions. Missing feeds, network failures, or invalid metadata
-   leave the current installation usable and do not block startup.
-3. Show an update card with current/new versions, release notes, Update, Later,
-   and Skip. Wisp handles the download after confirmation; users do not select
-   ZIPs or enter checksums.
-4. Validate feed schema, repository, plugin ID, runtime requirements and the
-   version-pinned asset origin/path. Enforce HTTPS including redirects and bounded
-   downloads. Check size, digest and extracted plugin identity/version before
-   using Wisp's staged installer.
-5. Serialize installs and defer replacement while the plugin is in use. Preserve
+1. Provide an update-page link and an Update action for the separately installed
+   SFL plugin, using the Browser Bridge update interaction as a UI precedent.
+2. Read the trusted feed on demand and compare with the installed version. Show
+   the available version and release information. Missing feeds, network failures,
+   invalid metadata, or no newer version leave the current installation usable.
+3. On Update, automatically download the Wisp-specific package. Validate feed
+   schema, repository, plugin ID, runtime requirements and the version-pinned
+   asset origin/path. Enforce HTTPS including redirects and bounded downloads.
+   Check size, digest and extracted plugin identity/version before using Wisp's
+   staged installer. Do not downgrade a newer installed plugin.
+4. Serialize installs and defer replacement while the plugin is in use. Preserve
    bindings, user data and project enabled state. Keep the previous package until
    a fresh MCP initialize/tools-list and `figure_library_source_status` succeed;
-   restore it on failure. `setup_required` on first use is a setup prompt, not an
-   installation failure.
+   restore it on failure. `setup_required` is a setup prompt, not an installation
+   failure; an update must not choose or overwrite Library/workspace roots.
 
-Wisp Browser Bridge provides a UI/lifecycle precedent, but compares the connected
-extension with Wisp's bundled copy. GitHub discovery is additional work, and its
-browser reload commands cannot restart this stdio MCP server.
+Wisp Browser Bridge compares a connected extension with Wisp's bundled copy.
+SFL reuses its update interaction, while obtaining packages from SFL Releases
+only when requested. Browser reload commands cannot restart this stdio MCP server.


### PR DESCRIPTION
SFL is an optional, separately installed plugin. Its size should not increase Wisp's installer. After installing SFL, users should have a link to its release/update page and an Update action that downloads and installs the Wisp-specific package automatically.

This documentation-only follow-up to #14 removes bundled initial deployment and startup polling from the host requirements. It describes on-demand updates, preserves existing user bindings, and distinguishes viewing the release-page link from triggering installation. The release feed implementation remains useful without bundling SFL.

Related: #13 and https://github.com/xuzhougeng/wisp-science/issues/1219.

Validation: reviewed the revised contract and `git diff --check` passed. No runtime code changed; tests were not rerun. Wisp's update entry and installer integration remain host-side work.
