### PR TITLE
完善候选图选择、绘图规范记忆与项目图归档工作流

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -34,6 +34,15 @@ import {
   type WorkbenchDisplayMode,
 } from "./display-mode.ts";
 import "./styles.css";
+import { mountPlottingTips } from "./plotting-tips.ts";
+import { mountProjectFigures } from "./project-figures.ts";
+
+let preferenceStorage: Storage | undefined;
+try { preferenceStorage = window.localStorage; } catch { /* Embedded host may deny storage. */ }
+mountPlottingTips(document, document.getElementById("plotting-help")!, {
+  storage: preferenceStorage,
+  copy: (text) => navigator.clipboard.writeText(text),
+});
 
 const root = document.getElementById("app")!;
 const cards = document.getElementById("cards")!;
@@ -80,6 +89,17 @@ const app = new App(
   { availableDisplayModes: ["inline", "fullscreen", "pip"] },
 );
 
+mountProjectFigures(document, document.getElementById("project-figures")!, async (name, input) => {
+  if (!serverToolsAvailable()) throw Error("当前宿主无法在界面调用项目工具，请在对话中请求项目图或投稿导出。");
+  const result = await app.callServerTool({ name, arguments: input });
+  if (result.isError) throw Error(result.content.filter((c) => c.type === "text").map((c) => c.text).join("\n"));
+  if (!result.structuredContent) throw Error("项目工具未返回有效数据");
+  return result.structuredContent;
+}, async (figure, locale) => {
+  if (!updateModelContextAvailable()) throw Error("请在对话中请求 Agent 准备该图的所选语言投稿包。");
+  await app.updateModelContext({ content: [{ type: "text", text: `Prepare submission language ${locale} for project figure ${figure.id} (${figure.title}), revision ${figure.revision}. Read figure-organization and prepare separate translated code/prose and rerendered labels where necessary. Preserve originals; verify behavior and call figure_library_prepare_submission. Do not export yet: the user will review the file inventory in the App.` }] });
+});
+
 brandLogo.src = SFL_BRAND_ICON_DATA_URI;
 emptyIcon.replaceChildren(createIcon(document, "image", "sfl-icon state-icon-svg"));
 statusIcon.replaceChildren(createIcon(document, "layers", "sfl-icon"));
@@ -100,7 +120,6 @@ let activeResult: SearchResult | undefined;
 let activeResultSetId: string | undefined;
 let activeDetail: DetailViewElements | undefined;
 const pageCache = new Map<number, SearchResult>();
-const reportedCapabilities = new Set<string>();
 const selectedCandidates = new Map<string, Candidate>();
 
 const DEFAULT_TITLE = "选择科学绘图模板";
@@ -267,10 +286,6 @@ function render(result: SearchResult) {
       refreshPlotSetBar();
     },
     onDetail: (candidate, elements, opener) => {
-      if (opener === elements.previewButton) {
-        void recordUiEvent("candidate.thumbnail_clicked", candidate);
-      }
-      void recordUiEvent("candidate.detail_opened", candidate);
       activeDetail = openCandidateDetail({
         document,
         candidate,
@@ -282,7 +297,6 @@ function render(result: SearchResult) {
           if (result.isError) throw new Error("Host could not open documentation link");
         },
         onClosed: () => {
-          void recordUiEvent("candidate.detail_closed", candidate);
           activeDetail = undefined;
         },
         onRequestExactPreview: (detail) => void loadExactPreview(candidate, detail),
@@ -291,19 +305,14 @@ function render(result: SearchResult) {
     },
   });
   status.textContent = serverToolsAvailable()
-    ? "请先在 App 内浏览候选详情；只有你请求精确预览并确认后，才会把选择交给 Agent。"
+    ? "点击标题或空白处选择，查看详情用于浏览。以已选标记和计数为准；工具审批不代表已选模板。"
     : updateModelContextAvailable()
       ? "当前 Host 未提供 serverTools；可勾选 1 到 8 个模板交给 Agent 绘制，或打开详情做单张审核。"
       : "当前 Host 既未提供 serverTools，也未提供 updateModelContext；只能浏览当前页基础详情。";
   if (result.diagnosticsDegraded) {
     status.textContent += " 诊断日志处于降级状态。";
   }
-  const first = result.candidates[0];
   refreshPlotSetBar();
-  if (first && !reportedCapabilities.has(result.resultSetId) && serverToolsAvailable()) {
-    reportedCapabilities.add(result.resultSetId);
-    void recordUiEvent("host.capabilities_detected", first);
-  }
 }
 
 async function submitPlotSet() {

--- a/app/mcp-app.html
+++ b/app/mcp-app.html
@@ -26,6 +26,8 @@
         </div>
       </header>
       <p id="pip-summary" class="pip-summary" hidden></p>
+      <section id="plotting-help" aria-label="绘图提示"></section>
+      <section id="project-figures" aria-label="项目图与投稿导出"></section>
 
       <section id="empty" class="empty" aria-live="polite">
         <span id="empty-icon" class="state-icon" aria-hidden="true"></span>
@@ -33,7 +35,7 @@
       </section>
       <section id="cards" class="cards" aria-label="Scientific figure template candidates"></section>
       <section id="plot-set-bar" class="plot-set-bar" aria-label="多选绘图模板">
-        <span id="plot-set-count">已选 0 个模板</span>
+        <span id="plot-set-count" role="status" aria-live="polite" aria-atomic="true">已选 0 个模板</span>
         <button id="plot-set-submit" type="button" disabled>交给 Agent 绘制（0）</button>
       </section>
       <nav id="pagination" class="pagination" aria-label="候选分页">
@@ -43,7 +45,7 @@
       </nav>
       <footer id="status" aria-live="polite">
         <span id="status-icon" class="status-icon" aria-hidden="true"></span>
-        <span id="status-text">分数只表示召回顺序。打开基础详情不会调用 Agent；可勾选 1 到 8 个模板后点“交给 Agent 绘制”。打开详情不会调用 Agent。</span>
+        <span id="status-text">点击标题或卡片空白处选择模板，“查看详情”用于浏览。工具运行审批不代表模板已选中；请以“已选”标记和计数为准。</span>
       </footer>
     </main>
     <script type="module" src="/main.ts"></script>

--- a/app/plotting-tips.ts
+++ b/app/plotting-tips.ts
@@ -1,0 +1,38 @@
+export const PLOTTING_EXAMPLE = "使用已选模板和这份数据，生成用于 A4 PPT 拼版的子图，宽 85 mm，统一 Arial，同组同色；导出 PDF 和 600 DPI PNG，并检查文字重叠、裁切和字体是否生效。其他样式保留模板设置。";
+
+export function mountPlottingTips(document: Document, parent: HTMLElement, options: {
+  storage?: Pick<Storage, "getItem" | "setItem">;
+  copy: (text: string) => Promise<void>;
+}) {
+  const tips = document.createElement("details");
+  tips.className = "plotting-tips";
+  let collapsed = false;
+  try { collapsed = options.storage?.getItem("sfl.plotting-tips.collapsed") === "true"; } catch { /* Restricted host storage. */ }
+  tips.open = !collapsed;
+  const summary = document.createElement("summary");
+  summary.textContent = "科研绘图提示 · 自然语言就能表达需求";
+  tips.append(summary);
+  for (const text of [
+    "可以告诉模型：图的用途或期刊要求、数据文件与列名、分组及单位、最终宽高（mm/cm）、字体字号、分组配色、线宽、输出格式与 DPI。可提供参考图；没有特殊要求可沿用模板，不必一次填齐。",
+    "按最终放置尺寸出图，同一实验组跨图保持同色。请说明线宽指坐标轴、图例框还是整图外框。示例数值不是通用投稿标准，不能为了美观改变数据或统计含义。",
+    "字体需检查是否安装；导出格式取决于绘图后端。PDF/SVG 矢量内容与 PNG 栅格 DPI 不同，提高低分辨率图片的 DPI 数值不会增加细节。交付前检查文字裁切、重叠、图例颜色和单位。",
+    "选择模板只在本界面标记；宿主的工具运行审批不代表已选模板。确认已选计数后，点击“交给 Agent 绘制”。",
+    "想跨会话沿用规范，可以说“记住我的实验室绘图规范：Arial，A 组蓝色、B 组橙色，宽 85 mm，导出 PDF 和 600 DPI PNG”。也可查看、修改或重置；说“仅这次宽 100 mm”不会改写长期规范。",
+  ]) {
+    const paragraph = document.createElement("p"); paragraph.textContent = text; tips.append(paragraph);
+  }
+  const example = document.createElement("blockquote"); example.textContent = PLOTTING_EXAMPLE;
+  const copy = document.createElement("button"); copy.type = "button"; copy.textContent = "复制示例";
+  const status = document.createElement("span"); status.setAttribute("role", "status");
+  copy.addEventListener("click", async () => {
+    copy.disabled = true;
+    try { await options.copy(PLOTTING_EXAMPLE); status.textContent = "已复制，可在对话中修改后使用。"; }
+    catch { status.textContent = "无法访问剪贴板，请选中上方示例手动复制。"; }
+    finally { copy.disabled = false; }
+  });
+  tips.addEventListener("toggle", () => {
+    try { options.storage?.setItem("sfl.plotting-tips.collapsed", String(!tips.open)); } catch { /* Optional preference. */ }
+  });
+  tips.append(example, copy, status); parent.append(tips);
+  return tips;
+}

--- a/app/project-figures.ts
+++ b/app/project-figures.ts
@@ -1,0 +1,89 @@
+type ToolCall = (name: string, input: Record<string, unknown>) => Promise<Record<string, unknown>>;
+type Figure = { id: string; title: string; revision: number; directory: string; label: { figure: number; panel: string } | null; artworkLabelPending: boolean };
+
+export function mountProjectFigures(document: Document, parent: HTMLElement, call: ToolCall, prepare: (figure: Figure, locale: string) => Promise<void>) {
+  const section = document.createElement("details"); section.className = "plotting-tips";
+  const summary = document.createElement("summary"); summary.textContent = "我的项目图 · 归档与投稿包";
+  const hint = document.createElement("p"); hint.textContent = "这里显示已绑定工作区的项目图，可用自然语言规划 Figure 1 A–H、继续子图、改名或交换编号。每幅图分别保存数据、脚本和修订；已规划不代表已生成。";
+  const load = document.createElement("button"); load.type = "button"; load.textContent = "刷新项目图";
+  const status = document.createElement("p"); status.setAttribute("role", "status");
+  const list = document.createElement("div");
+  section.append(summary, hint, load, status, list); parent.append(section);
+  load.addEventListener("click", async () => {
+    load.disabled = true; status.textContent = "正在读取已绑定工作区…";
+    try {
+      const result = await call("figure_library_list_project_figures", {});
+      const figures = result.figures as Figure[]; list.replaceChildren();
+      for (const figure of figures) {
+        const row = document.createElement("p");
+        row.append(document.createTextNode(`${figure.label ? `Figure ${figure.label.figure}${figure.label.panel} · ` : ""}${figure.title} · ${figure.revision ? `修订 ${figure.revision}` : "计划中，未归档"}${figure.artworkLabelPending ? " · 图内编号待更新" : ""} `));
+        const button = document.createElement("button"); button.type = "button"; button.textContent = "导出投稿包"; button.disabled = !figure.revision;
+        button.addEventListener("click", () => openSubmissionDialog(document, figure, call, prepare, button));
+        row.append(button); list.append(row);
+      }
+      status.textContent = figures.length ? `共 ${figures.length} 幅项目图` : "暂无项目图。可在对话中说“先规划 Figure 1 的 A、B 两幅子图”。";
+    } catch (error) { status.textContent = String(error); }
+    finally { load.disabled = false; }
+  });
+  return section;
+}
+
+export function openSubmissionDialog(document: Document, figure: Figure, call: ToolCall, prepare: (figure: Figure, locale: string) => Promise<void>, opener: HTMLButtonElement) {
+  const dialog = document.createElement("dialog"); dialog.className = "submission-dialog";
+  dialog.setAttribute("aria-label", `导出 ${figure.title} 投稿包`);
+  const title = document.createElement("h2"); title.textContent = `导出投稿包 · ${figure.title}`;
+  const languageLabel = document.createElement("label"); languageLabel.textContent = "导出语言 ";
+  const language = document.createElement("select");
+  for (const [value, text] of [["zh-CN", "中文版"], ["en", "English version"]]) {
+    const option = document.createElement("option"); option.value = value!; option.textContent = text!; language.append(option);
+  }
+  languageLabel.append(language);
+  const scope = document.createElement("p");
+  const status = document.createElement("p"); status.setAttribute("role", "status");
+  const inventory = document.createElement("pre"); inventory.className = "submission-inventory";
+  const preview = document.createElement("button"); preview.type = "button"; preview.textContent = "检查并预览文件清单";
+  const preparation = document.createElement("button"); preparation.type = "button"; preparation.textContent = "让 Agent 准备所选语言";
+  const submit = document.createElement("button"); submit.type = "button"; submit.textContent = "导出"; submit.disabled = true;
+  const cancel = document.createElement("button"); cancel.type = "button"; cancel.textContent = "取消";
+  let planDigest: string | undefined; let busy = false; let generation = 0;
+  const updateScope = () => {
+    generation++; planDigest = undefined; submit.disabled = true; inventory.textContent = "";
+    scope.textContent = language.value === "en"
+      ? "英文版：生成的说明、代码注释及图中展示文字使用英文。原始数据、原始作者脚本、许可证、引用和真实标识保持原貌。需要翻译的图由 Agent 重绘并验证。"
+      : "中文版：README 和配套说明使用中文，生成/适配代码使用英文注释与标识。图中文字保留当前语言。";
+    scope.textContent += " 导出副本存入工作区 exports，不覆盖工作文件；不会自动上传或提交期刊。";
+  };
+  updateScope(); language.addEventListener("change", updateScope);
+  const setBusy = (value: boolean) => { busy = value; language.disabled = value; preview.disabled = value; preparation.disabled = value; submit.disabled = value || !planDigest; };
+  preview.addEventListener("click", async () => {
+    const request = ++generation; planDigest = undefined; setBusy(true); status.textContent = "正在检查归档与所选语言…";
+    try {
+      const plan = await call("figure_library_plan_submission_export", { figureId: figure.id, locale: language.value });
+      if (!dialog.open || request !== generation) return;
+      planDigest = plan.digest as string;
+      inventory.textContent = `目标：${plan.destination}\n\n${(plan.files as Array<{ path: string; bytes: number }>).map((f) => `${f.path} (${f.bytes} bytes)`).join("\n")}\nmanifest.json（导出时记录时间、语言、来源修订及文件校验值）\n\n保留原貌：${(plan.exceptions as string[]).join("; ")}`;
+      status.textContent = "检查通过。请审阅文件清单，然后点击“导出”。";
+    } catch (error) { if (dialog.open) status.textContent = String(error); }
+    finally { setBusy(false); }
+  });
+  preparation.addEventListener("click", async () => {
+    setBusy(true);
+    try { await prepare(figure, language.value); status.textContent = "已将语言准备请求交给 Agent。完成后重新检查文件清单。"; }
+    catch (error) { status.textContent = String(error); }
+    finally { setBusy(false); }
+  });
+  submit.addEventListener("click", async () => {
+    if (busy || !planDigest) return;
+    setBusy(true); cancel.disabled = true; status.textContent = "正在打包…";
+    try {
+      const result = await call("figure_library_apply_submission_export", { planDigest });
+      status.textContent = `已导出：${result.path}`; planDigest = undefined; cancel.textContent = "关闭";
+    } catch (error) { status.textContent = String(error); planDigest = undefined; }
+    finally { setBusy(false); cancel.disabled = false; }
+  });
+  cancel.addEventListener("click", () => dialog.close());
+  dialog.addEventListener("cancel", (event) => { if (cancel.disabled) event.preventDefault(); });
+  dialog.addEventListener("close", () => { generation++; dialog.remove(); opener.focus(); });
+  dialog.append(title, languageLabel, scope, preparation, preview, inventory, status, submit, cancel);
+  document.body.append(dialog); dialog.showModal(); return dialog;
+}

--- a/app/styles.css
+++ b/app/styles.css
@@ -204,8 +204,8 @@ footer {
 .candidate-title:hover:not(:disabled),
 .candidate-title:focus-visible:not(:disabled) {
   background: transparent;
-  color: #1d6849;
-  outline: 2px solid currentColor;
+  color: inherit;
+  outline: 2px solid #58b79d;
   outline-offset: 2px;
 }
 
@@ -694,7 +694,10 @@ footer {
 
 .plot-set-bar button {
   min-width: 0;
+  width: auto;
 }
+
+.plot-set-bar > span { flex-shrink: 0; white-space: nowrap; }
 
 .header-side {
   display: grid;
@@ -886,3 +889,22 @@ html[data-theme="dark"] .warning-list {
     justify-content: flex-start;
   }
 }
+
+.card { cursor: pointer; }
+.card.is-selected { border: 2px solid #229577; box-shadow: 0 0 0 2px #22957733; }
+.card:hover { outline: 1px solid #22957788; }
+.candidate-select { font-weight: 700; font-size: .95rem; padding: 8px; }
+.candidate-select-input { width: 24px; height: 24px; accent-color: #16846a; }
+.is-selected .candidate-select { color: var(--color-text-primary, #16644f); background: #22957722; border-radius: 6px; }
+.plot-set-bar { position: sticky; bottom: 8px; z-index: 5; border: 1px solid #22957766; box-shadow: 0 4px 20px #0002; }
+.plotting-tips { margin: 14px 0; padding: 14px; border: 1px solid #22957755; border-radius: 10px; }
+.plotting-tips summary { cursor: pointer; font-weight: 700; }
+.plotting-tips p { line-height: 1.65; }
+.plotting-tips blockquote { margin: 12px 0; padding-left: 14px; border-left: 3px solid #229577; }
+#app[data-display-mode="pip"] .plotting-tips { display: none; }
+.submission-dialog { width: min(680px, 90vw); max-height: 85vh; overflow: auto; border: 1px solid #229577; border-radius: 14px; background: var(--color-background-primary, #fff); color: var(--color-text-primary, #172d25); padding: 24px; }
+.submission-dialog::backdrop { background: #0008; }
+.submission-dialog button { margin: 6px; }
+.submission-dialog p { line-height: 1.6; }
+.submission-inventory { white-space: pre-wrap; overflow-wrap: anywhere; font-size: .85rem; }
+#app[data-display-mode="pip"] #project-figures { display: none; }

--- a/app/view.ts
+++ b/app/view.ts
@@ -366,8 +366,8 @@ export function renderCandidateCards(options: {
     selectBox.checked = Boolean(options.selectedIds?.has(candidate.candidateId));
     selectBox.setAttribute("aria-label", `选择 ${candidate.title} 交给 Agent 绘制`);
     selectBox.addEventListener("click", (event) => event.stopPropagation());
-    selectBox.addEventListener("change", () => options.onToggleSelect?.(candidate, selectBox.checked));
-    selectLabel.append(selectBox, document.createTextNode("选择"));
+    const selectionText = element(document, "span");
+    selectLabel.append(selectBox, selectionText);
     const previewButton = button(
       document,
       "preview preview-button",
@@ -385,7 +385,26 @@ export function renderCandidateCards(options: {
     const heading = element(document, "div");
     const headingNode = element(document, "h2", "module");
     const titleButton = button(document, "candidate-title", candidate.title);
-    titleButton.setAttribute("aria-label", `查看 ${candidate.title} 详情`);
+    titleButton.setAttribute("aria-label", `选择 ${candidate.title}`);
+    const syncSelection = () => {
+      card.classList.toggle("is-selected", selectBox.checked);
+      titleButton.setAttribute("aria-pressed", String(selectBox.checked));
+      selectionText.textContent = selectBox.checked ? "✓ 已选" : "选择此模板";
+    };
+    const toggleSelection = () => {
+      selectBox.checked = !selectBox.checked;
+      syncSelection();
+      options.onToggleSelect?.(candidate, selectBox.checked);
+    };
+    selectBox.addEventListener("change", () => {
+      syncSelection();
+      options.onToggleSelect?.(candidate, selectBox.checked);
+    });
+    card.addEventListener("click", (event) => {
+      const target = event.target as Element;
+      if (!target.closest("button, input, label, a")) toggleSelection();
+    });
+    syncSelection();
     headingNode.append(titleButton);
     heading.append(
       headingNode,
@@ -417,7 +436,7 @@ export function renderCandidateCards(options: {
     const elements = { card, previewButton, titleButton, detailButton };
     const open = (opener: HTMLButtonElement) => options.onDetail(candidate, elements, opener);
     previewButton.addEventListener("click", () => open(previewButton));
-    titleButton.addEventListener("click", () => open(titleButton));
+    titleButton.addEventListener("click", toggleSelection);
     detailButton.addEventListener("click", () => open(detailButton));
     content.append(detailButton);
     card.append(selectLabel, previewButton, content);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -85,6 +85,18 @@ try {
   const listed = await client.listTools();
   const names = listed.tools.map((tool) => tool.name).sort();
   const required = [
+    "figure_library_get_style_profile",
+    "figure_library_save_style_profile",
+    "figure_library_reset_style_profile",
+    "figure_library_resolve_style",
+    "figure_library_list_project_figures",
+    "figure_library_plan_project_figures",
+    "figure_library_apply_project_figures",
+    "figure_library_archive_project_figure",
+    "figure_library_check_project_figure",
+    "figure_library_prepare_submission",
+    "figure_library_plan_submission_export",
+    "figure_library_apply_submission_export",
     "figure_library_open",
     "figure_library_search",
     "figure_library_search_page",

--- a/skills/figure-library/SKILL.md
+++ b/skills/figure-library/SKILL.md
@@ -23,6 +23,8 @@ path.
 
 ## Bundled companion Skills
 
+For user project figures, naming/renaming, cross-session continuation and submission packages, use `figure_library_list_project_figures` and the [project figure workflow](../figure-organization/references/project-figures.md). These project tools are separate from template library publication/export. For explicit style-memory requests, follow [figure-style](../figure-style/SKILL.md). The App exposes collapsible drawing tips and a separate project-figure/export section.
+
 Use the copies shipped beside this Skill, not similarly named Host installations.
 - Before creating/updating template prose use [figure-description](../figure-description/SKILL.md).
   Pass independent Markdown description/application/dataProfile, with a non-empty application

--- a/skills/figure-organization/SKILL.md
+++ b/skills/figure-organization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figure-organization
-description: Organize R or Python figure-replication and adaptation scripts into readable, owner-editable workflows with Chinese navigation comments and traceable inputs and outputs. Use when creating or reorganizing code for a selected SFL template, not for browsing templates or restructuring an unrelated application.
+description: Name and track project figures and panels, organize reproducible R or Python plotting scripts and data, archive revisions, and prepare Chinese or English submission packages. Use for project plotting workflows and figure renaming, not browsing templates or restructuring unrelated applications.
 ---
 
 # Figure Organization
@@ -20,6 +20,8 @@ Respect the active project's AGENTS instructions, directories, language and exec
 - Never install dependencies, execute a downloaded installer, run an upstream analysis, or infer authorization from successful SFL materialization. Use only the execution scope the user has granted.
 
 ## On-demand references
+
+For new figures and revisions, follow [project figures and submission archives](references/project-figures.md). Plan a stable project figure ID before adapting code; the default is one directory per independent figure/panel under the project's accepted figure root. Main-figure labels are logical groups, not automatically assembled artwork. Saved plotting data, actual scripts, provenance and truthful render evidence are required for complete archives. This supersedes loose output-file naming for managed project figures.
 
 For analysis scripts read [script organization](references/script-organization.md) and, when outputs matter, [output binding](references/output-binding.md). Read [workflow lineage](references/workflow-lineage.md) only for multi-step work needing it. [Source organization](references/source-organization.md) is relevant only when there is actual reusable library code; do not force it onto one figure.
 

--- a/skills/figure-organization/references/project-figures.md
+++ b/skills/figure-organization/references/project-figures.md
@@ -1,0 +1,36 @@
+# Project figure workflow
+
+Use the bound project workspace. Do not confuse a public template ID with a user's project figure identity. The tools store a project index under `.sfl-project`, isolated from the global template library. They do not execute code, install dependencies, assemble PPT slides, or submit to journals.
+
+## Plan, find and rename
+
+1. Read `figure_library_list_project_figures` before continuing an existing figure. Search stable ID, display name or `Figure 1B`. Historical names may match several entries: show candidates and ask only if the intended figure is ambiguous.
+2. For new figures, call `figure_library_plan_project_figures`. Supply a useful title and English descriptive `slug` (especially for non-English titles); optionally set `label: {figure: 1, panel: "B"}`. A standalone plot does not need a paper number. Use the accepted project figure directory through `figuresDirectory`, rather than reorganizing unrelated files.
+3. Review the plan's before/after paths and labels, then apply its `digest` with `figure_library_apply_project_figures`. Explicitly requested creation, naming or reordering provides authorization; do not re-ask for already clear information. Batch B/C exchanges in one plan. The stable ID survives renaming; old labels remain historical aliases. External absolute paths are not rewritten automatically: check affected scripts/references and explain any unresolved ones.
+4. Planning A–H creates planned entries, not rendered outputs. Only archive successfully executed panels as complete. Main-figure groups are represented by labels in the project index; individual directories remain independent archive units.
+
+## Work and archive
+
+Use the returned working directory. Preserve materialized templates and author scripts unchanged. Keep real adapted scripts in `scripts/`, actual plotting data in `data/`, and rendered files in `outputs/`; do not create empty helper directories. Original experimental data, analysis results and actual plot data have different roles. Large shared raw data may remain outside the figure folder with a truthful version/hash and retrieval reference.
+
+Before plotting, resolve the user's effective style through `figure_library_resolve_style`. Save its result in `details.style`. Write the actual adapted script and plotting data to disk. Execute only through the authorized host runtime. For a successful render, record SHA-256 for the exact plot data, plotting/preprocessing scripts and outputs, plus the verification time. Supply these in `details.renderEvidence: {files: {"data/plot-data.csv": "<sha256>", ...}, verifiedAt: "<ISO timestamp>"}`. Changed files cannot reuse a previous render's evidence.
+
+Call `figure_library_archive_project_figure` with the stable `figureId`, current `expectedRevision`, explicit artifacts, and filled details. Each artifact has `path` relative to the figure folder, role, description and source. Use `plot_data` for the actual table plotted, `analysis_data` for upstream results, and `raw_data` only for actual raw inputs. Use `original_script` for immutable author code and `plot_script` for the actual adapted code. Network sources need real URLs/DOIs/commits when known; local sources need honest identifiers. Unknown sources remain incomplete, never invented. The archive contains only listed files, not an automatic copy of the whole project.
+
+Fill purpose, data description (columns, units, missing-value handling), script responsibilities, actual environment, parameters, sources, relative reproduction command, execution status/notes, changes and package scope. Say when no upstream script exists. Set `panelLabelInArtwork` to the actual rendered panel letter, or null when the artwork has no panel label. Renaming a rendered panel requires checking/rerendering its label before export. Failed/not-run work can be recorded but is not complete. Do not rerun costly upstream analysis merely to change style.
+
+The tool creates an immutable snapshot under `.sfl-project/revisions/<figure-id>/<revision>/` with README.md, manifest.json, parameters.json, provenance.json, environment.txt and the declared files. `figure.json` in the working figure directory points to its revision history. The generated README contains all nine required sections; no empty placeholder is considered a complete archive. Use `figure_library_check_project_figure` to check hashes and missing roles/sources. Hash integrity is distinct from the host's execution and visual checks.
+
+## Chinese / English submission copies
+
+The App's “我的项目图” → “导出投稿包” lets the user select a language, ask the Agent to prepare it, review the file inventory, and export or cancel. Preparation alone never creates a ZIP.
+
+- `zh-CN`: generated README and explanations are Chinese; adapted/generated code identifiers, comments and docstrings are English. Preserve the current artwork language.
+- `en`: generated prose, adapted code and generated artwork labels are English. Translate scientifically ambiguous labels only after resolving their meaning. Preserve original data fields, samples/genes, original scripts, licenses and source citations. Use explicit display-label mappings instead of renaming scientific identifiers.
+- Preserve workspace scripts and original material. Write prepared copies under a separate directory inside the figure folder and pass mappings `{originalPath, preparedPath}`. Both languages require English generated code; convert this Skill's Chinese navigation comments only in the export copy. Represent preserved non-English data-key string literals with language-appropriate escapes if needed; never rename actual data columns for a code-language check.
+- For either locale supply `readmeSections` (purpose, dataDescription, scriptDescription, environment, provenanceNotes, executionNotes, scope, changes) in the selected language, plus translated `fileDescriptions` for generated file descriptions. Translating headings alone is insufficient. Use `labels` to record original/translated display text. Changed labels require actual rerendered files in every output format. Verify code behavior and scientific equivalence in the host; do not claim a renamed image was translated.
+- Call `figure_library_prepare_submission` with figure ID, locale and `translation` including prepared files, labels, truthful `verified` and verification notes. An unverified translation is not ready. Then use the App's inventory preview or `figure_library_plan_submission_export` followed by `figure_library_apply_submission_export` for a requested, reviewed export. Stale prepared content must be prepared again.
+
+ZIPs use `exports/<slug>-r<revision>-<locale>.zip`, preserve source files and cannot overwrite earlier exports. Unavailable/local-only external dependencies prevent complete export; a resolvable archival reference is listed explicitly and means the package is not self-contained. The package README explains whether it contains plotting source data, analysis results or raw experiments. It never guarantees every journal's raw-data requirements.
+
+Deliver a concise mapping: paper label → title → stable ID/revision → working directory and archive/export paths. Report planned panels, missing sources, unverified checks and stale artwork honestly.

--- a/skills/figure-style/SKILL.md
+++ b/skills/figure-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figure-style
-description: Check correctness, legibility and faithful visual reproduction of selected scientific figure templates in R or Python. Use when adapting plotting code or inspecting rendered output, not for browsing templates. Includes an optional matplotlib sidecar and R-specific guidance; does not install packages or execute code automatically.
+description: Apply explicitly saved user plotting preferences, check correctness and legibility, and reproduce selected scientific figure templates in R or Python. Use for saving or overriding style defaults, adapting plotting code or inspecting rendered output, not browsing templates. Does not install packages or execute code automatically.
 license: Apache-2.0
 ---
 
@@ -16,8 +16,15 @@ Use this plugin's Skill rather than a Host copy. Follow the user's selected back
 
 1. Data and semantic truth: labels, thresholds, colour mappings and summaries must agree with the actual data and analysis.
 2. The user's explicit current requirements.
-3. The selected template's layout, palette, font, legend, axes and visual identity.
-4. General style defaults only where the reference/user does not specify an answer.
+3. The enabled user's saved style profile, unless this task explicitly requests faithful template reproduction.
+4. The selected template's layout, palette, font, legend, axes and visual identity.
+5. General style defaults only where the reference/user does not specify an answer.
+
+Before adapting plotting code, call `figure_library_resolve_style` with known template settings and current overrides. Pass `faithfulTemplate: true` for an explicit faithful-reproduction request. Read the returned effective settings and apply them in the host's plotting backend; the tool itself does not enforce rendering. Explain conflicting settings actually chosen. Preserve semantic group keys when applying saved colors and never alter statistical methods or data.
+
+Only use `figure_library_save_style_profile` when the user explicitly asks to remember or change defaults; first read `figure_library_get_style_profile` and use its revision. Saving replaces the settings, so preserve unrelated preferences when making an incremental change. Use `figure_library_reset_style_profile` for an explicit reset. Current-task overrides must not be saved implicitly.
+
+Example: “记住我的实验室绘图规范：Arial，A 组蓝色、B 组橙色，宽 85 mm，导出 PDF 和 600 DPI PNG。” Another task can say “这次宽 100 mm，其他沿用实验室规范” without changing the saved profile. Store the resolved profile revision, effective parameters and current overrides in the figure archive's `details.style`. Check actual fonts, sizes, group colors and backend format support; report missing fonts or unverified output rather than claiming compliance from configuration alone.
 
 Do not silently replace a palette, font, chart type, legend, grid or layout to comply with a generic aesthetic preference. Where the reference has low contrast, overlaps or inconsistent labels, explain the issue and propose a change; do not conceal the defect or call a restyled version a faithful reproduction. Never alter data to make a preferred shape. Plotting a synthetic scaffold is not reproducing the original experiment.
 

--- a/src/figure-workflow-tools.ts
+++ b/src/figure-workflow-tools.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { WorkspaceRuntime } from "./workspace-runtime.ts";
+import { StyleProfileStore, StyleSettings } from "./style-profile.ts";
+import { ArchiveDetails, Artifact, ExportTranslation, FigureChange, ProjectFigures, type FigureChangePlan, type ExportPlan } from "./project-figures.ts";
+import { atomicJson, readJsonOr, safePath, withWorkflowLock } from "./workflow-storage.ts";
+import type { ToolOutcomeEnvelope } from "./library-binding-tools.ts";
+
+function response(data: Record<string, unknown>, error?: string) {
+  const envelope: ToolOutcomeEnvelope = { schema: "figure-library.tool-outcome.v1", outcome: error ? "failed" : "ok", terminal: true, retrySameCall: false, code: error ? "figure_workflow_failed" : "figure_workflow_ok", summary: error ?? "Figure workflow operation completed", nextAction: error ? "inspect_review" : "none" };
+  return { ...(error ? { isError: true } : {}), content: [{ type: "text" as const, text: `OUTCOME: ${envelope.outcome}\nTERMINAL: true\nRETRY_SAME_CALL: false\nCODE: ${envelope.code}\nNEXT_ACTION: ${envelope.nextAction}\n${envelope.summary}\n${JSON.stringify(data)}` }], structuredContent: { envelope, ...data } };
+}
+
+export function registerFigureWorkflowTools(server: McpServer, workspaceRuntime: WorkspaceRuntime, profiles = new StyleProfileStore()) {
+  const changePlans = new Map<string, { root: string; plan: FigureChangePlan }>();
+  const exportPlans = new Map<string, { root: string; plan: ExportPlan }>();
+  async function project() {
+    const workspace = await workspaceRuntime.current();
+    if (!workspace.confirmed || !workspace.directory) throw Error("Bind a project workspace before managing project figures");
+    return new ProjectFigures(workspace.directory);
+  }
+  function register<S extends z.ZodRawShape>(name: string, description: string, shape: S, readOnly: boolean, run: (input: z.infer<z.ZodObject<S>>) => Promise<unknown>) {
+    server.registerTool(name, { description, inputSchema: shape as z.ZodRawShape, _meta: { ui: { visibility: ["model", "app"] } }, annotations: { readOnlyHint: readOnly, destructiveHint: false, idempotentHint: readOnly, openWorldHint: false } }, async (raw) => {
+      try {
+        const value = await run(z.object(shape).strict().parse(raw));
+        const data = value as Record<string, unknown>;
+        return response(data);
+      } catch (error) {
+        return response({}, error instanceof Error ? error.message : String(error));
+      }
+    });
+  }
+  register("figure_library_get_style_profile", "Read the local user's saved style profile without modifying it. Disabled or absent profiles preserve template behavior.", {}, true, () => profiles.read());
+  register("figure_library_save_style_profile", "Explicitly save or replace the user's long-term style preferences. Only use when the user asks to remember/change their defaults; never persist temporary instructions. Read current revision first.", { expectedRevision: z.number().int().nonnegative(), name: z.string().max(200), settings: StyleSettings, enabled: z.boolean().optional() }, false, (input) => profiles.save(input));
+  register("figure_library_reset_style_profile", "Explicitly reset saved defaults while preserving the revision counter. Does not modify figures.", { expectedRevision: z.number().int().nonnegative() }, false, ({ expectedRevision }) => profiles.reset(expectedRevision));
+  register("figure_library_resolve_style", "Read effective settings before adapting plotting code: template < enabled saved profile < current overrides. faithfulTemplate bypasses saved preferences. Semantic truth always takes priority. Host applies and verifies settings; this tool does not execute code.", { template: StyleSettings.optional(), overrides: StyleSettings.optional(), faithfulTemplate: z.boolean().optional() }, true, ({ template, overrides, faithfulTemplate }) => profiles.resolve(template, overrides, faithfulTemplate));
+  register("figure_library_list_project_figures", "Find generated or planned project figures by stable ID, name, historical alias or Figure 1B. Multiple matches need disambiguation. Does not search public templates.", { query: z.string().max(500).optional() }, true, async ({ query }) => (await project()).list(query));
+  register("figure_library_plan_project_figures", "Plan independent figures or panels before plotting. New entries need title and descriptive English slug for non-English titles. Label is optional (standalone figures do not occupy Figure 1). Batch updates permit panel swaps. Review before/after paths before apply. Planning A-H does not mark any panel rendered.", { changes: z.array(FigureChange).min(1).max(100), figuresDirectory: z.string().max(240).optional() }, true, async ({ changes, figuresDirectory }) => {
+    const p = await project(); const plan = await p.plan(changes, figuresDirectory);
+    if (changePlans.size >= 64) changePlans.delete(changePlans.keys().next().value!);
+    changePlans.set(plan.digest, { root: p.workspace, plan }); return plan;
+  });
+  register("figure_library_apply_project_figures", "Apply a reviewed naming/grouping plan. Preserves stable IDs and historical revisions; moves working directories without overwriting targets. Does not render changed panel letters or rewrite external absolute references.", { planDigest: z.string().regex(/^[a-f0-9]{64}$/u) }, false, async ({ planDigest }) => {
+    const cached = changePlans.get(planDigest); const p = await project();
+    if (!cached || cached.root !== p.workspace) throw Error("Plan expired or workspace changed; make a fresh plan");
+    const result = await p.apply(cached.plan); changePlans.delete(planDigest); return result;
+  });
+  register("figure_library_archive_project_figure", "Snapshot only the explicitly listed figure files under its working directory. Include real plotting data and actual scripts, parameters, environment and truthful sources. Distinguish raw experiments from analysis tables. Host reports execution; SFL never runs scripts. Returns integrity issues instead of treating incomplete archives as complete.", { figureId: z.string().uuid(), expectedRevision: z.number().int().nonnegative(), artifacts: z.array(Artifact).max(200), details: ArchiveDetails }, false, async ({ figureId, expectedRevision, artifacts, details }) => (await project()).archive(figureId, expectedRevision, artifacts, details));
+  register("figure_library_check_project_figure", "Verify current archive hashes, required data/script/output roles, sources, execution report and artwork label state. This does not rerun code or validate scientific conclusions.", { figureId: z.string().uuid() }, true, async ({ figureId }) => (await project()).check(figureId));
+  const translationInput = { figureId: z.string().uuid(), locale: z.enum(["zh-CN", "en"]) };
+  register("figure_library_prepare_submission", "Record host-prepared language export copies after checking their code behavior and rerendered output. Both locales require English generated code; en also requires translated generated prose and plot labels. Original data/scripts remain unchanged. Records preparation only; no ZIP is generated. User reviews the file inventory before applying export.", { ...translationInput, translation: ExportTranslation }, false, async ({ figureId, locale, translation }) => {
+    const p = await project(); const plan = await p.planExport(figureId, locale, translation);
+    await withWorkflowLock(p.store, async () => {
+      await atomicJson(await safePath(p.store, `export-${figureId}-${locale}.json`), { schema: "sfl.export-preparation.v1", sourceDigest: plan.sourceDigest, packageDigest: plan.packageDigest, translation });
+    });
+    return { ready: true, plan, note: "Choose language, review inventory and confirm export in the App, or call plan/apply submission export." };
+  });
+  async function preparation(p: ProjectFigures, figureId: string, locale: "zh-CN" | "en") {
+    const prepared = await readJsonOr<{ schema: string; sourceDigest: string; packageDigest: string; translation: z.infer<typeof ExportTranslation> } | null>(await safePath(p.store, `export-${figureId}-${locale}.json`), null);
+    if (!prepared || prepared.schema !== "sfl.export-preparation.v1") throw Error("请先让 Agent 准备所选语言的说明、英文代码和必要的重绘，再重试导出。");
+    const plan = await p.planExport(figureId, locale, prepared.translation);
+    if (plan.sourceDigest !== prepared.sourceDigest) throw Error("Figure revision changed; prepare this language again");
+    if (plan.packageDigest !== prepared.packageDigest) throw Error("Prepared files changed after host verification; prepare this language again");
+    return { plan, translation: prepared.translation };
+  }
+  register("figure_library_plan_submission_export", "Preview language-specific submission ZIP inventory and destination. Requires a complete archive and current host-verified language preparation; writes no ZIP. This is figure source-data packaging, not automatic journal compliance.", translationInput, true, async ({ figureId, locale }) => {
+    const p = await project(); const { plan } = await preparation(p, figureId, locale);
+    if (exportPlans.size >= 64) exportPlans.delete(exportPlans.keys().next().value!);
+    exportPlans.set(plan.digest, { root: p.workspace, plan }); return plan;
+  });
+  register("figure_library_apply_submission_export", "Generate the reviewed language ZIP without overwriting existing files. Rechecks source/translation digests and workspace. No upload, journal submission or arbitrary execution.", { planDigest: z.string().regex(/^[a-f0-9]{64}$/u) }, false, async ({ planDigest }) => {
+    const p = await project(); const cached = exportPlans.get(planDigest);
+    if (!cached || cached.root !== p.workspace) throw Error("Export plan expired or workspace changed");
+    const { translation } = await preparation(p, cached.plan.figureId, cached.plan.locale);
+    const result = await p.applyExport(cached.plan, translation); exportPlans.delete(planDigest); return result;
+  });
+}

--- a/src/project-figures.ts
+++ b/src/project-figures.ts
@@ -1,0 +1,409 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { zipSync } from "fflate";
+import { assertMcpImageBytes } from "./image-validation.ts";
+import { atomicJson, digest, jsonText, readJsonOr, safePath, safeRelative, withWorkflowLock } from "./workflow-storage.ts";
+
+const text = z.string().trim().min(1).max(10000);
+const id = z.string().uuid();
+const slug = z.string().regex(/^[a-z][a-z0-9-]{0,99}$/u).refine((v) => { try { safeRelative(v); return true; } catch { return false; } }, "Unsafe file name");
+const rel = z.string().refine((v) => { try { safeRelative(v); return true; } catch { return false; } }, "Unsafe relative path");
+const Label = z.object({ figure: z.number().int().min(1).max(9999), panel: z.string().regex(/^[A-Z]{1,2}$/u) }).strict();
+export const FigureChange = z.object({ id: id.optional(), title: text, slug: slug.optional(), label: Label.nullable().optional(), purpose: text.optional() }).strict();
+export const Artifact = z.object({
+  path: rel, role: z.enum(["raw_data", "analysis_data", "plot_data", "original_script", "plot_script", "preprocess_script", "output", "documentation"]),
+  description: text,
+  source: z.object({ kind: z.enum(["local", "url", "generated", "unknown"]), reference: text, version: text.optional(), acquiredAt: text.optional(), author: text.optional(), license: text.optional() }).strict(),
+}).strict();
+export const ArchiveDetails = z.object({
+  purpose: text, dataDescription: text, scriptDescription: text, environment: text,
+  parameters: z.record(z.string(), z.unknown()), provenanceNotes: text,
+  runCommand: text, execution: z.enum(["not_run", "failed", "succeeded"]), executionNotes: text,
+  scope: text, changes: text,
+  externalDependencies: z.array(z.object({ reference: text, description: text, availability: z.enum(["local_only", "archived", "missing"]), sha256: z.string().regex(/^[a-f0-9]{64}$/u).optional() }).strict()).default([]),
+  originalScript: z.enum(["included", "none", "missing"]),
+  style: z.record(z.string(), z.unknown()).optional(),
+  panelLabelInArtwork: z.string().nullable(),
+  renderEvidence: z.object({ files: z.record(rel, z.string().regex(/^[a-f0-9]{64}$/u)), verifiedAt: text }).strict().optional(),
+}).strict();
+export type ArchiveDetailsValue = z.infer<typeof ArchiveDetails>;
+type LabelValue = z.infer<typeof Label>;
+type FileRecord = z.infer<typeof Artifact> & { bytes: number; sha256: string };
+type Revision = { revision: number; directory: string; manifestSha256: string };
+export type ProjectFigure = { id: string; title: string; slug: string; directory: string; label: LabelValue | null; purpose: string; aliases: string[]; revision: number; history: Revision[]; artworkLabelPending: boolean };
+type ProjectState = { schema: "sfl.project-figures.v1"; revision: number; figuresDirectory: string; figures: ProjectFigure[] };
+type Manifest = { schema: "sfl.figure-archive.v1"; figureId: string; title: string; label: LabelValue | null; revision: number; createdAt: string; files: FileRecord[]; details: ArchiveDetailsValue; generated: Record<string, { sha256: string; bytes: number }> };
+export type FigureChangePlan = { schema: "sfl.figure-change-plan.v1"; expectedRevision: number; next: ProjectState; changes: Array<{ id: string; before: string | null; after: string; label: LabelValue | null }>; digest: string };
+export type ExportPlan = { schema: "sfl.submission-plan.v1"; figureId: string; revision: number; locale: "zh-CN" | "en"; destination: string; files: Array<{ path: string; bytes: number; sha256: string }>; generatedManifest: { path: "manifest.json"; assignedOnExport: ["exportedAt"] }; sourceDigest: string; packageDigest: string; digest: string; exceptions: string[] };
+export const ExportTranslation = z.object({
+  // Host prepares translations as separate files inside this figure's working directory.
+  readmeSections: z.object({ purpose: text, dataDescription: text, scriptDescription: text, environment: text, provenanceNotes: text, executionNotes: text, scope: text, changes: text }).strict().optional(),
+  files: z.array(z.object({ originalPath: rel, preparedPath: rel }).strict()).default([]),
+  labels: z.array(z.object({ original: text, translated: text }).strict()).default([]),
+  verified: z.boolean(),
+  notes: text,
+  fileDescriptions: z.record(rel, text).optional(),
+}).strict();
+type Translation = z.infer<typeof ExportTranslation>;
+
+const labelText = (label: LabelValue | null) => label ? `Figure ${label.figure}${label.panel}` : "";
+const english = (v: string) => !/[\u3400-\u9fff]/u.test(v);
+const substantive = (v: string) => !/^(todo|tbd|待补充|待填写|unknown|n\/a|\.\.\.)[.!。\s]*$/iu.test(v.trim());
+
+function validateOutput(file: string, data: Uint8Array) {
+  const extension = path.extname(file).toLowerCase(); const value = Buffer.from(data);
+  if ([".png", ".jpg", ".jpeg", ".webp"].includes(extension)) {
+    assertMcpImageBytes({ bytes: data, extension, mimeType: extension === ".png" ? "image/png" : extension === ".webp" ? "image/webp" : "image/jpeg" }); return;
+  }
+  if (extension === ".svg" && /<svg\b[^>]*(?:viewBox|width)\s*=/iu.test(value.toString()) && /<\/(?:\w+:)?svg\s*>/iu.test(value.toString()) && /<(?:path|rect|circle|line|polygon|polyline|text|image|use)\b/iu.test(value.toString())) return;
+  if (extension === ".pdf" && value.subarray(0, 5).toString() === "%PDF-" && value.subarray(-1024).toString().includes("%%EOF")) return;
+  if ([".tif", ".tiff"].includes(extension) && value.length > 8 && ["49492a00", "4d4d002a", "49492b00", "4d4d002b"].includes(value.subarray(0, 4).toString("hex"))) return;
+  if (extension === ".eps" && value.subarray(0, 24).toString().startsWith("%!PS-Adobe") && value.toString().includes("%%BoundingBox:")) return;
+  throw Error(`Output has unsupported or invalid image structure: ${file}`);
+}
+
+function figureReadme(figure: ProjectFigure) {
+  return `# ${labelText(figure.label)} ${figure.title}\n\nStable ID: ${figure.id}\n\n${figure.purpose}\n\nDirectory: ${figure.directory}\n\nRevision: ${figure.revision || "planned; not rendered"}\n\nArtwork label needs rendering: ${figure.artworkLabelPending}\n\nHistorical names: ${figure.aliases.join("; ") || "none"}\n\nUse the project archive tool to capture actual data, scripts, environment and outputs after the host renders them.\n`;
+}
+
+function archiveReadme(manifest: Manifest, locale: "zh-CN" | "en" = "zh-CN") {
+  const d = manifest.details;
+  const translated = (zh: string, en: string) => locale === "en" ? en : zh;
+  const headings = locale === "en"
+    ? ["Identity and purpose", "File index", "Data", "Scripts and reproduction", "Environment", "Parameters and style", "Sources and permissions", "Execution and checks", "Revision and package scope"]
+    : ["图的身份与目的", "文件索引", "数据说明", "脚本说明与重绘", "运行环境", "参数与图形规范", "来源与授权", "执行与检查状态", "修订与投稿包范围"];
+  const sections = [
+    `${manifest.figureId} · ${labelText(manifest.label)} · ${translated("修订", "revision")} ${manifest.revision}\n\n${d.purpose}`,
+    manifest.files.map((f) => `- [${f.path}](<${f.path}>) — ${f.description}`).join("\n"),
+    `${d.dataDescription}\n\n${translated("包外依赖", "External dependencies")}:\n${d.externalDependencies.map((v) => `- ${v.reference}: ${v.description} (${v.availability})`).join("\n") || translated("未声明包外依赖", "None declared")}`,
+    `${d.scriptDescription}\n\n${translated("工作目录：解压后的包根目录", "Working directory: package root")}\n\n\`\`\`text\n${d.runCommand}\n\`\`\`\n\n${translated("原始脚本", "Original script")}: ${locale === "en" ? d.originalScript : ({ included: "已包含", none: "没有上游原始脚本", missing: "缺失" })[d.originalScript]}`,
+    d.environment,
+    translated("详见 [parameters.json](parameters.json)。保存的设置不代表已验证实际渲染符合规范。", "See [parameters.json](parameters.json). Saved settings are not proof of rendered compliance."),
+    `${d.provenanceNotes}\n\n${translated("详见 [provenance.json](provenance.json)。来源链接可离线记录，未验证在线可访问性。", "See [provenance.json](provenance.json). Links recorded offline; reachability is not verified.")}`,
+    `${locale === "en" ? d.execution : ({ succeeded: "已执行", failed: "执行失败", not_run: "未执行" })[d.execution]}: ${d.executionNotes}\n\n${translated("完整性检查核对已保存文件；代码执行与图形检查由宿主报告，并非 SFL 自行执行。", "Integrity validation checks saved files; execution and visual checks are reported by the host, not performed by SFL.")}`,
+    `${d.changes}\n\n${d.scope}`,
+  ];
+  return `# ${manifest.title}\n\n${headings.map((h, i) => `## ${i + 1}. ${h}\n\n${sections[i]}\n`).join("\n")}`;
+}
+
+export class ProjectFigures {
+  readonly workspace: string;
+  readonly store: string;
+  constructor(workspace: string) {
+    if (!path.isAbsolute(workspace)) throw Error("Project workspace must be absolute");
+    this.workspace = path.resolve(workspace); this.store = path.join(this.workspace, ".sfl-project");
+  }
+  async state(): Promise<ProjectState> {
+    const recovery = await readJsonOr<unknown>(await safePath(this.store, "pending-change.json"), null);
+    if (recovery) throw Error(`Interrupted project change: inspect ${path.join(this.store, "pending-change.json")} and the writer lock before recovery; do not start another rename`);
+    const state = await readJsonOr<ProjectState>(await safePath(this.store, "state.json"), { schema: "sfl.project-figures.v1", revision: 0, figuresDirectory: "figures", figures: [] });
+    if (state.schema !== "sfl.project-figures.v1" || !Number.isSafeInteger(state.revision) || !Array.isArray(state.figures)) throw Error("Invalid project state");
+    safeRelative(state.figuresDirectory);
+    for (const f of state.figures) { id.parse(f.id); slug.parse(f.slug); safeRelative(f.directory); if (f.label) Label.parse(f.label); }
+    return state;
+  }
+  async list(query?: string) {
+    const state = await this.state();
+    const q = query?.trim().toLowerCase();
+    const figures = state.figures.filter((f) => !q || [f.id, f.title, f.slug, labelText(f.label), ...f.aliases].some((v) => v.toLowerCase().includes(q)));
+    return { ...state, figures, ambiguous: figures.length > 1 && Boolean(q), note: "These are project figures, not public templates. Historical aliases may be ambiguous." };
+  }
+  async plan(changes: z.infer<typeof FigureChange>[], figuresDirectory?: string): Promise<FigureChangePlan> {
+    const state = await this.state();
+    const next = structuredClone(state);
+    if (figuresDirectory) {
+      safeRelative(figuresDirectory);
+      if (state.figures.length && state.figuresDirectory !== figuresDirectory) throw Error("Existing project figure root cannot be changed by this operation");
+      next.figuresDirectory = figuresDirectory;
+    }
+    const moves: FigureChangePlan["changes"] = [];
+    const changed = new Set<string>();
+    for (const raw of changes) {
+      const change = FigureChange.parse(raw);
+      const old = change.id ? next.figures.find((f) => f.id === change.id) : undefined;
+      if (change.id && !old) throw Error("Unknown figure ID");
+      const figureId = old?.id ?? randomUUID();
+      if (changed.has(figureId)) throw Error("Duplicate figure change"); changed.add(figureId);
+      const label = change.label === undefined ? old?.label ?? null : change.label;
+      const fallback = change.title.toLowerCase().replace(/[^a-z0-9]+/gu, "-").replace(/^-|-$/gu, "").slice(0, 70);
+      const prefix = label ? `fig${String(label.figure).padStart(2, "0")}${label.panel.toLowerCase()}-` : "";
+      const name = slug.parse(change.slug ?? (old && change.label === undefined ? old.slug : `${prefix}${fallback || "figure"}`));
+      const directory = `${next.figuresDirectory}/${name}`;
+      const aliases = [...new Set([...(old?.aliases ?? []), ...(old ? [old.title, labelText(old.label)] : [])].filter(Boolean))];
+      const figure: ProjectFigure = { id: figureId, title: change.title, slug: name, directory, label, purpose: change.purpose ?? old?.purpose ?? change.title,
+        aliases, revision: old?.revision ?? 0, history: old?.history ?? [], artworkLabelPending: old?.artworkLabelPending === true || Boolean(old?.revision && labelText(old.label) !== labelText(label)) };
+      if (old) next.figures[next.figures.indexOf(old)] = figure; else next.figures.push(figure);
+      moves.push({ id: figureId, before: old?.directory ?? null, after: directory, label });
+    }
+    const paths = new Set<string>(); const labels = new Set<string>();
+    for (const f of next.figures) {
+      if (paths.has(f.directory.toLowerCase())) throw Error("File name conflict; provide a distinct descriptive slug"); paths.add(f.directory.toLowerCase());
+      if (f.label) { const label = labelText(f.label); if (labels.has(label)) throw Error("Figure/panel label conflict; exchange panels in one batch"); labels.add(label); }
+    }
+    for (const move of moves) {
+      const target = await safePath(this.workspace, move.after);
+      if (move.before !== move.after && !moves.some((v) => v.before === move.after)) {
+        try { await fs.lstat(target); throw Error(`Destination already exists: ${move.after}`); }
+        catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+      }
+    }
+    next.revision++;
+    const plan = { schema: "sfl.figure-change-plan.v1" as const, expectedRevision: state.revision, next, changes: moves };
+    return { ...plan, digest: digest(jsonText(plan)) };
+  }
+  async apply(plan: FigureChangePlan) {
+    const { digest: expected, ...body } = plan;
+    if (digest(jsonText(body)) !== expected) throw Error("Changed project plan");
+    return withWorkflowLock(this.store, async () => {
+      const previous = await this.state(); if (previous.revision !== plan.expectedRevision) throw Error("Stale project plan; refresh before applying");
+      const staged: Array<{ before: string; stage: string; after: string }> = [];
+      const created: string[] = [];
+      const recoveryPath = await safePath(this.store, "pending-change.json");
+      const moveStages = new Map(plan.changes.map((move) => [move.id, `move-${randomUUID()}`]));
+      await atomicJson(recoveryPath, { schema: "sfl.project-change-recovery.v1", previous, next: plan.next,
+        changes: plan.changes.map((move) => ({ ...move, stagingDirectory: `.sfl-project/${moveStages.get(move.id)!}` })) });
+      // Cycles (B/C exchanges) use unique intermediate directories. Roll back on failure.
+      try {
+        for (const move of plan.changes) {
+          if (!move.before || move.before === move.after) continue;
+          const before = await safePath(this.workspace, move.before);
+          const stage = await safePath(this.store, moveStages.get(move.id)!);
+          await fs.rename(before, stage); staged.push({ before, stage, after: await safePath(this.workspace, move.after) });
+        }
+        for (const move of staged) {
+          await fs.mkdir(path.dirname(move.after), { recursive: true });
+          try { await fs.lstat(move.after); throw Error("Destination appeared during rename"); } catch (e) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+          await fs.rename(move.stage, move.after);
+        }
+        for (const move of plan.changes.filter((m) => !m.before)) {
+          const target = await safePath(this.workspace, move.after);
+          await fs.mkdir(path.dirname(target), { recursive: true }); await fs.mkdir(target); created.push(target);
+        }
+        for (const f of plan.next.figures.filter((f) => plan.changes.some((m) => m.id === f.id))) {
+          await atomicJson(await safePath(this.workspace, `${f.directory}/figure.json`), { schema: "sfl.figure.v1", ...f });
+          await this.writeWorkingMetadata(f);
+        }
+        await atomicJson(await safePath(this.store, "state.json"), plan.next);
+        await fs.rm(recoveryPath);
+      } catch (error) {
+        // Move all completed destinations back to staging before restoring a cycle.
+        for (const move of staged) { try { await fs.lstat(move.stage); } catch { await fs.rename(move.after, move.stage); } }
+        for (const move of staged) await fs.rename(move.stage, move.before);
+        for (const target of created) { for (const name of ["figure.json", "README.md", "manifest.json"]) await fs.rm(path.join(target, name), { force: true }); await fs.rmdir(target); }
+        for (const f of previous.figures.filter((f) => plan.changes.some((m) => m.id === f.id))) {
+          await atomicJson(await safePath(this.workspace, `${f.directory}/figure.json`), { schema: "sfl.figure.v1", ...f });
+          await this.writeWorkingMetadata(f);
+        }
+        await atomicJson(await safePath(this.store, "state.json"), previous);
+        await fs.rm(recoveryPath, { force: true });
+        throw error;
+      }
+      return { ...plan.next, note: "Relative in-folder references remain valid. External absolute references are not rewritten. Changed labels in existing artwork require a host render before export." };
+    });
+  }
+  private async figure(figureId: string) {
+    id.parse(figureId); const state = await this.state(); const figure = state.figures.find((f) => f.id === figureId);
+    if (!figure) throw Error("Unknown project figure ID; search the project index first");
+    return { state, figure };
+  }
+  async archive(figureId: string, expectedRevision: number, artifacts: z.infer<typeof Artifact>[], rawDetails: ArchiveDetailsValue) {
+    const details = ArchiveDetails.parse(rawDetails);
+    return withWorkflowLock(this.store, async () => {
+      const { state, figure } = await this.figure(figureId);
+      if (figure.revision !== expectedRevision) throw Error("Stale figure revision");
+      const previousState = structuredClone(state);
+      const revision = figure.revision + 1;
+      const relative = `revisions/${figure.id}/${revision}-${randomUUID()}`;
+      const destination = await safePath(this.store, relative);
+      const files: FileRecord[] = []; const bytes = new Map<string, Uint8Array>(); const used = new Set<string>();
+      let total = 0;
+      for (const raw of artifacts) {
+        const artifact = Artifact.parse(raw);
+        if (/^(?:exports|revisions|\.sfl-project)(?:\/|$)/iu.test(artifact.path) || /\.(?:zip|tgz)$/iu.test(artifact.path)
+          || /(?:^|\/)(?:\.env(?:\..*)?|id_rsa|credentials[^/]*|token[^/]*|secrets?[^/]*)$/iu.test(artifact.path)
+          || ["readme.md", "manifest.json", "parameters.json", "provenance.json", "environment.txt", "figure.json"].includes(artifact.path.toLowerCase())) throw Error(`Reserved or excluded archive path: ${artifact.path}`);
+        if (used.has(artifact.path.toLowerCase())) throw Error("Case-insensitive archive path collision"); used.add(artifact.path.toLowerCase());
+        const source = await safePath(this.workspace, `${figure.directory}/${artifact.path}`);
+        const stat = await fs.stat(source); if (!stat.isFile() || stat.size === 0 || stat.size > 64 * 1024 * 1024) throw Error(`Missing, empty or oversized artifact: ${artifact.path}`);
+        total += stat.size; if (total > 128 * 1024 * 1024) throw Error("Archive exceeds 128 MiB; reference shared raw data externally");
+        const data = await fs.readFile(source);
+        if (artifact.role === "output") validateOutput(artifact.path, data);
+        files.push({ ...artifact, bytes: data.length, sha256: digest(data) }); bytes.set(artifact.path, data);
+      }
+      const manifest: Manifest = { schema: "sfl.figure-archive.v1", figureId, title: figure.title, label: figure.label, revision, createdAt: new Date().toISOString(), files, details, generated: {} };
+      if (details.execution === "succeeded") {
+        if (!details.renderEvidence) throw Error("A successful render needs host-recorded input/script/output hashes from the actual execution");
+        for (const file of files.filter((f) => ["plot_data", "plot_script", "preprocess_script", "output"].includes(f.role))) {
+          if (details.renderEvidence.files[file.path] !== file.sha256) throw Error(`File changed since verified render: ${file.path}`);
+        }
+      }
+      const previous = figure.history.length ? await this.snapshot(figureId) : undefined;
+      for (const file of files.filter((f) => f.role === "original_script")) {
+        const original = previous?.manifest.files.find((f) => f.role === "original_script" && f.path === file.path);
+        if (original && original.sha256 !== file.sha256) throw Error("Original author script was overwritten; preserve the old original and use a distinct versioned path");
+      }
+      const generated = this.generatedFiles(manifest);
+      for (const [name, data] of Object.entries(generated)) manifest.generated[name] = { bytes: Buffer.byteLength(data), sha256: digest(data) };
+      await fs.mkdir(destination, { recursive: true });
+      for (const [name, data] of [...bytes, ...Object.entries(generated)]) {
+        const target = await safePath(destination, name); await fs.mkdir(path.dirname(target), { recursive: true }); await fs.writeFile(target, data, { flag: "wx" });
+      }
+      const serialized = jsonText(manifest); await fs.writeFile(path.join(destination, "manifest.json"), serialized, { flag: "wx" });
+      figure.revision = revision; figure.history.push({ revision, directory: relative, manifestSha256: digest(serialized) });
+      figure.artworkLabelPending = Boolean(figure.label && details.panelLabelInArtwork !== figure.label.panel);
+      state.revision++;
+      const metadataBefore: Array<{ file: string; bytes: Buffer | null }> = [];
+      for (const name of ["figure.json", "README.md", "manifest.json", "parameters.json", "provenance.json", "environment.txt"]) {
+        const file = await safePath(this.workspace, `${figure.directory}/${name}`);
+        let bytes: Buffer | null = null;
+        try { bytes = await fs.readFile(file); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+        metadataBefore.push({ file, bytes });
+      }
+      const recoveryPath = await safePath(this.store, "pending-change.json");
+      await atomicJson(recoveryPath, { schema: "sfl.archive-recovery.v1", previous: previousState, next: state,
+        metadata: metadataBefore.map(({ file, bytes }) => ({ path: path.relative(this.workspace, file).split(path.sep).join("/"), beforeBase64: bytes?.toString("base64") ?? null })) });
+      try {
+        await this.writeWorkingMetadata(figure);
+        await atomicJson(await safePath(this.workspace, `${figure.directory}/figure.json`), { schema: "sfl.figure.v1", ...figure });
+        await atomicJson(await safePath(this.store, "state.json"), state);
+        await fs.rm(recoveryPath);
+      } catch (error) {
+        for (const { file, bytes } of metadataBefore) {
+          if (bytes === null) await fs.rm(file, { force: true }); else await fs.writeFile(file, bytes);
+        }
+        await atomicJson(await safePath(this.store, "state.json"), previousState);
+        await fs.rm(recoveryPath, { force: true });
+        throw error;
+      }
+      return { figure, archiveDirectory: destination, ...(await this.check(figureId)) };
+    });
+  }
+  private generatedFiles(manifest: Manifest, locale: "zh-CN" | "en" = "zh-CN") {
+    return { "README.md": archiveReadme(manifest, locale), "parameters.json": jsonText({ schema: "sfl.figure-parameters.v1", values: manifest.details.parameters, style: manifest.details.style ?? null }),
+      "provenance.json": jsonText({ schema: "sfl.figure-provenance.v1", files: manifest.files.map((f) => ({ path: f.path, sha256: f.sha256, role: f.role, source: f.source })), externalDependencies: manifest.details.externalDependencies }),
+      "environment.txt": manifest.details.environment + "\n" };
+  }
+  private async writeWorkingMetadata(figure: ProjectFigure) {
+    const last = figure.history.at(-1);
+    if (!last) {
+      await fs.writeFile(await safePath(this.workspace, `${figure.directory}/README.md`), figureReadme(figure));
+      await atomicJson(await safePath(this.workspace, `${figure.directory}/manifest.json`), { schema: "sfl.figure-working.v1", figureId: figure.id, title: figure.title, label: figure.label, status: "planned", revision: 0, files: [] });
+      return;
+    }
+    const archive = await safePath(this.store, last.directory);
+    const raw = await fs.readFile(await safePath(archive, "manifest.json"), "utf8");
+    if (digest(raw) !== last.manifestSha256) throw Error("Archive manifest changed; cannot synchronize working metadata");
+    const manifest = JSON.parse(raw) as Manifest;
+    manifest.title = figure.title; manifest.label = figure.label;
+    for (const [name, content] of Object.entries(this.generatedFiles(manifest))) {
+      await fs.writeFile(await safePath(this.workspace, `${figure.directory}/${name}`), content);
+    }
+    await fs.appendFile(await safePath(this.workspace, `${figure.directory}/README.md`), `\n${figure.artworkLabelPending ? "图内编号待重新渲染；不能将现有图片认作新编号的完成产物。\n" : ""}\n归档快照：${path.relative(path.join(this.workspace, figure.directory), archive).split(path.sep).join("/")}\n\n工作文件修改后需要重新归档；历史快照保持不变。\n`);
+    await atomicJson(await safePath(this.workspace, `${figure.directory}/manifest.json`), { schema: "sfl.figure-working.v1", figureId: figure.id, title: figure.title, label: figure.label, revision: figure.revision, sourceArchive: last.directory, sourceManifestSha256: last.manifestSha256, artworkLabelPending: figure.artworkLabelPending, files: manifest.files });
+  }
+  private async snapshot(figureId: string) {
+    const { figure } = await this.figure(figureId); const revision = figure.history.at(-1);
+    if (!revision) throw Error("Figure is planned and has no archive revision");
+    const directory = await safePath(this.store, revision.directory);
+    const raw = await fs.readFile(await safePath(directory, "manifest.json"), "utf8");
+    if (digest(raw) !== revision.manifestSha256) throw Error("Archive manifest was modified");
+    const manifest = JSON.parse(raw) as Manifest;
+    if (manifest.schema !== "sfl.figure-archive.v1" || manifest.figureId !== figure.id || manifest.revision !== figure.revision) throw Error("Archive identity mismatch");
+    return { figure, directory, manifest, revision };
+  }
+  async check(figureId: string) {
+    const { figure, directory, manifest, revision } = await this.snapshot(figureId); const errors: string[] = [];
+    for (const file of [...manifest.files, ...Object.entries(manifest.generated).map(([name, v]) => ({ path: name, ...v }))]) {
+      try { const data = await fs.readFile(await safePath(directory, file.path)); if (data.length !== file.bytes || digest(data) !== file.sha256) errors.push(`Changed file: ${file.path}`); }
+      catch { errors.push(`Missing or unsafe file: ${file.path}`); }
+    }
+    for (const role of ["plot_data", "plot_script", "output"] as const) if (!manifest.files.some((f) => f.role === role)) errors.push(`Missing role: ${role}`);
+    for (const [key, value] of Object.entries(manifest.details)) if (typeof value === "string" && !substantive(value)) errors.push(`Incomplete description: ${key}`);
+    if (manifest.details.execution !== "succeeded") errors.push(`Render ${manifest.details.execution}`);
+    if (!manifest.files.filter((f) => f.role === "plot_script").some((f) => manifest.details.runCommand.includes(f.path))) errors.push("Reproduction command does not reference the saved plotting script");
+    if (/(?:[A-Za-z]:[\\/]|\/(?:Users|home|tmp|mnt)\/|\.\.[\\/])/u.test(manifest.details.runCommand)) errors.push("Reproduction command requires a path outside the package");
+    if (manifest.details.originalScript === "missing" || (manifest.details.originalScript === "included" && !manifest.files.some((f) => f.role === "original_script"))) errors.push("Original script missing");
+    for (const f of manifest.files) if (f.source.kind === "unknown" || !substantive(f.source.reference)) errors.push(`Unknown source: ${f.path}`);
+    if (figure.artworkLabelPending) errors.push("Artwork panel label has not been updated");
+    if (manifest.details.externalDependencies.some((d) => d.availability === "missing" || d.availability === "local_only")) errors.push("Package depends on missing or local-only external data");
+    return { complete: errors.length === 0, errors, executionVerification: "host-reported", selfContained: manifest.details.externalDependencies.length === 0, revision: manifest.revision, sourceDigest: revision.manifestSha256 };
+  }
+  private async exportBytes(figureId: string, locale: "zh-CN" | "en", translation: Translation) {
+    const check = await this.check(figureId); if (!check.complete) throw Error(`Archive incomplete: ${check.errors.join("; ")}`);
+    const { figure, directory, manifest: saved, revision } = await this.snapshot(figureId);
+    if (check.sourceDigest !== revision.manifestSha256 || figure.artworkLabelPending) throw Error("Figure changed during archive verification; check it again");
+    const prepared = ExportTranslation.parse(translation);
+    if (!prepared.verified) throw Error("Host must verify translated code behavior and rerendered labels before exporting");
+    const manifest = structuredClone(saved); manifest.title = locale === "en" && !english(figure.title) ? figure.slug : figure.title; manifest.label = figure.label;
+    if (!prepared.readmeSections) throw Error("Language export requires all eight prepared README sections, not only translated headings");
+    Object.assign(manifest.details, prepared.readmeSections);
+    if (locale === "en") {
+      for (const value of Object.values(prepared.readmeSections)) if (!english(value)) throw Error("English README still contains untranslated Chinese text");
+      if (prepared.labels.some((v) => !english(v.translated))) throw Error("Untranslated generated figure label");
+    }
+    if (locale === "zh-CN" && Object.values(prepared.readmeSections).some((value) => english(value))) throw Error("Chinese export needs Chinese explanations in each prepared README section");
+    const output: Record<string, Uint8Array> = {}; const mappings = new Map(prepared.files.map((v) => [v.originalPath, v.preparedPath]));
+    if (mappings.size !== prepared.files.length || prepared.files.some((v) => !manifest.files.some((f) => f.path === v.originalPath))) throw Error("Duplicate or unknown translation target");
+    const exceptions: string[] = [];
+    for (const file of manifest.files) {
+      const immutable = ["raw_data", "analysis_data", "plot_data", "original_script"].includes(file.role);
+      const replacement = mappings.get(file.path);
+      if (prepared.fileDescriptions?.[file.path]) file.description = prepared.fileDescriptions[file.path]!;
+      if ((locale === "en" && !english(file.description)) || (locale === "zh-CN" && english(file.description))) {
+        const translatedDescription = prepared.fileDescriptions?.[file.path];
+        if (!translatedDescription || (locale === "en" ? !english(translatedDescription) : english(translatedDescription))) throw Error(`Translate the generated file description: ${file.path}`);
+        file.description = translatedDescription;
+      }
+      if (!immutable && !/^[\x20-\x7e]+$/u.test(file.path)) throw Error(`Generated export file names must use English: ${file.path}`);
+      if (replacement && immutable) throw Error("Translation must preserve original data and original scripts");
+      let data = await fs.readFile(await safePath(directory, file.path));
+      if (data.length !== file.bytes || digest(data) !== file.sha256) throw Error(`Archive file changed during export: ${file.path}`);
+      if (replacement) data = await fs.readFile(await safePath(this.workspace, `${figure.directory}/${replacement}`));
+      if (!data.length || data.length > 64 * 1024 * 1024) throw Error("Empty or oversized prepared export file");
+      if (file.role === "output") validateOutput(file.path, data);
+      if (["plot_script", "preprocess_script"].includes(file.role) && !english(data.toString("utf8"))) throw Error(`Generated code needs English comments/identifiers: ${file.path}. Preserve original fields through a display mapping or escaped string literals.`);
+      if (locale === "en" && file.role === "documentation" && !english(data.toString("utf8"))) throw Error(`Untranslated documentation: ${file.path}`);
+      if (immutable) exceptions.push(`${file.path}: original material preserved`);
+      output[file.path] = data; file.sha256 = digest(data); file.bytes = data.length;
+    }
+    if (locale === "en" && prepared.labels.some((v) => v.original !== v.translated) && !manifest.files.filter((f) => f.role === "output").every((f) => mappings.has(f.path))) throw Error("Changed figure labels require prepared rerendered outputs for every exported format");
+    const generated = this.generatedFiles(manifest, locale);
+    for (const [name, value] of Object.entries(generated)) output[name] = Buffer.from(value);
+    const files = Object.entries(output).map(([name, value]) => ({ path: name, bytes: value.length, sha256: digest(value) })).sort((a, b) => a.path.localeCompare(b.path));
+    output["manifest.json"] = Buffer.from(jsonText({ schema: "sfl.submission.v1", figureId, revision: figure.revision, label: figure.label, exportLocale: locale, sourceManifestSha256: revision.manifestSha256, sourceCreatedAt: saved.createdAt, files, languageVerification: "host-reported", labelMapping: prepared.labels, verificationNotes: prepared.notes, exceptions, selfContained: check.selfContained }));
+    return { figure, revision, output, exceptions };
+  }
+  async planExport(figureId: string, locale: "zh-CN" | "en", translation: Translation): Promise<ExportPlan> {
+    const { figure, revision, output, exceptions } = await this.exportBytes(figureId, locale, translation);
+    const destination = `exports/${figure.slug}-r${figure.revision}-${locale}.zip`;
+    await safePath(this.workspace, destination);
+    const inventory = Object.entries(output).map(([name, value]) => ({ path: name, bytes: value.length, sha256: digest(value) }));
+    const files = inventory.filter((file) => file.path !== "manifest.json");
+    const generatedManifest = { path: "manifest.json" as const, assignedOnExport: ["exportedAt"] as ["exportedAt"] };
+    const plan = { schema: "sfl.submission-plan.v1" as const, figureId, revision: figure.revision, locale, destination, files, generatedManifest, sourceDigest: revision.manifestSha256, packageDigest: digest(jsonText(inventory)), exceptions };
+    return { ...plan, digest: digest(jsonText(plan)) };
+  }
+  async applyExport(plan: ExportPlan, translation: Translation) {
+    return withWorkflowLock(this.store, async () => {
+      const fresh = await this.planExport(plan.figureId, plan.locale, translation);
+      if (fresh.digest !== plan.digest) throw Error("Export files or project changed after preview; review a fresh export plan");
+      const { output } = await this.exportBytes(plan.figureId, plan.locale, translation);
+      if (digest(jsonText(Object.entries(output).map(([name, value]) => ({ path: name, bytes: value.length, sha256: digest(value) })))) !== plan.packageDigest) throw Error("Export files changed while packaging");
+      const exportedAt = new Date().toISOString();
+      output["manifest.json"] = Buffer.from(jsonText({ ...JSON.parse(Buffer.from(output["manifest.json"]!).toString("utf8")), exportedAt }));
+      const target = await safePath(this.workspace, plan.destination);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      // Publish a complete ZIP in one no-overwrite operation. A failed write never leaves
+      // a partial ZIP at the final path; hard-link creation is atomic and exclusive.
+      const temporary = await safePath(this.workspace, `exports/.submission-${randomUUID()}.tmp`);
+      const zip = zipSync(output, { level: 6 });
+      try {
+        await fs.writeFile(temporary, zip, { flag: "wx" });
+        await fs.link(temporary, target);
+      } finally { await fs.rm(temporary, { force: true }); }
+      return { path: target, figureId: plan.figureId, revision: plan.revision, exportLocale: plan.locale, exportedAt, sha256: digest(zip), uploaded: false };
+    });
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import {
   CatalogIndex,
 } from "./catalog.ts";
 import { registerBundleTools } from "./bundle-tools.ts";
+import { registerFigureWorkflowTools } from "./figure-workflow-tools.ts";
 import { inspectLibraryWriteLock } from "./cross-runtime-lock.ts";
 import {
   type CurrentLibraryContext,
@@ -1930,6 +1931,7 @@ export async function createServer(options: {
     diagnostics,
   });
   registerBundleTools({ server, currentLibraries });
+  registerFigureWorkflowTools(server, workspaceRuntime);
   registerGitHubPublicationTools({ server });
   registerOpenFigurePrTools({
     ...options.openFigurePr,

--- a/src/style-profile.ts
+++ b/src/style-profile.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+import { z } from "zod";
+import { defaultLibraryLocatorPath } from "./library-runtime.ts";
+import { atomicJson, readJsonOr, safePath, withWorkflowLock } from "./workflow-storage.ts";
+
+const positive = z.number().finite().positive().max(10000);
+const semanticKey = z.string().min(1).max(100).refine((v) => !["__proto__", "constructor", "prototype"].includes(v));
+export const StyleSettings = z.object({
+  fontFamily: z.string().trim().min(1).max(150).optional(),
+  fontSizePt: z.object({ title: positive.optional(), axis: positive.optional(), legend: positive.optional(), panel: positive.optional() }).strict().optional(),
+  colors: z.record(semanticKey, z.string().regex(/^#[0-9a-f]{6}(?:[0-9a-f]{2})?$/iu)).optional(),
+  size: z.object({ width: positive, height: positive.optional(), unit: z.enum(["mm", "cm", "in"]) }).strict().optional(),
+  namedSizes: z.record(semanticKey, z.object({ width: positive, height: positive.optional(), unit: z.enum(["mm", "cm", "in"]) }).strict()).optional(),
+  lineWidthMm: positive.optional(),
+  legend: z.string().max(500).optional(),
+  panelLabels: z.string().max(500).optional(),
+  marginsMm: z.object({ top: positive, right: positive, bottom: positive, left: positive }).strict().optional(),
+  export: z.object({ formats: z.array(z.enum(["png", "pdf", "svg", "tiff", "jpeg", "eps"])).min(1).max(6), rasterDpi: z.number().int().min(72).max(9600).optional(), background: z.string().max(100).optional() }).strict().optional(),
+}).strict();
+export type StyleSettingsValue = z.infer<typeof StyleSettings>;
+const StoredStyle = z.object({ schema: z.literal("sfl.style-profile.v1"), revision: z.number().int().nonnegative(), enabled: z.boolean(), name: z.string(), settings: StyleSettings, updatedAt: z.string() }).strict();
+export type StoredStyleValue = z.infer<typeof StoredStyle>;
+
+function overlay(base: StyleSettingsValue, update: StyleSettingsValue): StyleSettingsValue {
+  const output = { ...base, ...update };
+  for (const key of ["colors", "fontSizePt", "namedSizes"] as const) {
+    if (base[key] || update[key]) (output as Record<string, unknown>)[key] = { ...base[key], ...update[key] };
+  }
+  return StyleSettings.parse(output);
+}
+
+export class StyleProfileStore {
+  readonly directory: string;
+  constructor(directory = path.join(path.dirname(defaultLibraryLocatorPath()), "style-profile")) { this.directory = directory; }
+  async read(): Promise<StoredStyleValue> {
+    return StoredStyle.parse(await readJsonOr(await safePath(this.directory, "state.json"), {
+      schema: "sfl.style-profile.v1", revision: 0, enabled: false, name: "", settings: {}, updatedAt: "",
+    }));
+  }
+  async save(input: { expectedRevision: number; settings: StyleSettingsValue; name: string; enabled?: boolean }) {
+    const settings = StyleSettings.parse(input.settings);
+    return withWorkflowLock(this.directory, async () => {
+      const previous = await this.read();
+      if (previous.revision !== input.expectedRevision) throw Error("Style profile changed; read it again before saving");
+      const next = StoredStyle.parse({ schema: previous.schema, revision: previous.revision + 1, enabled: input.enabled ?? true, name: input.name, settings, updatedAt: new Date().toISOString() });
+      await atomicJson(await safePath(this.directory, "state.json"), next); return next;
+    });
+  }
+  async reset(expectedRevision: number) { return this.save({ expectedRevision, settings: {}, name: "", enabled: false }); }
+  async resolve(template: StyleSettingsValue = {}, overrides: StyleSettingsValue = {}, faithfulTemplate = false) {
+    const profile = await this.read();
+    const templateSettings = StyleSettings.parse(template); const current = StyleSettings.parse(overrides);
+    const effective = overlay(profile.enabled && !faithfulTemplate ? overlay(templateSettings, profile.settings) : templateSettings, current);
+    return { schema: "sfl.effective-style.v1", profileRevision: profile.revision, profileApplied: profile.enabled && !faithfulTemplate, effective, overrides: current, faithfulTemplate,
+      validation: "Host must check fonts, backend support, dimensions and rendered output; saving settings does not execute or verify a plot." };
+  }
+}

--- a/src/workflow-storage.ts
+++ b/src/workflow-storage.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+
+export const digest = (data: string | Uint8Array) => createHash("sha256").update(data).digest("hex");
+export const jsonText = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
+
+export function safeRelative(value: string): string {
+  if (!value || value.length > 240 || value.includes("\\") || path.posix.isAbsolute(value)) throw Error("Use a relative forward-slash path");
+  for (const part of value.split("/")) {
+    if (!part || part === "." || part === ".." || /[<>:"|?*\x00-\x1f]/u.test(part) || /[. ]$/u.test(part)
+      || /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/iu.test(part)) throw Error(`Unsafe path: ${value}`);
+  }
+  return value;
+}
+
+// Check every existing component, including the root: archive readers must not follow links.
+export async function safePath(root: string, relative: string): Promise<string> {
+  safeRelative(relative);
+  const absoluteRoot = path.resolve(root);
+  const parsed = path.parse(absoluteRoot);
+  let current = parsed.root;
+  for (const part of path.relative(parsed.root, absoluteRoot).split(path.sep).filter(Boolean).concat(relative.split("/"))) {
+    current = path.join(current, part);
+    try { if ((await fs.lstat(current)).isSymbolicLink()) throw Error(`Symbolic links are not allowed: ${current}`); }
+    catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+  }
+  return current;
+}
+
+export async function readJsonOr<T>(file: string, fallback: T): Promise<T> {
+  try { return JSON.parse(await fs.readFile(file, "utf8")) as T; }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return fallback; throw error; }
+}
+
+export async function atomicJson(file: string, value: unknown) {
+  const temporary = `${file}.${randomUUID()}.tmp`;
+  await fs.writeFile(temporary, jsonText(value), { flag: "wx" });
+  try { await fs.rename(temporary, file); } finally { await fs.rm(temporary, { force: true }); }
+}
+
+export async function withWorkflowLock<T>(root: string, operation: () => Promise<T>): Promise<T> {
+  await safePath(root, "state.json");
+  await fs.mkdir(root, { recursive: true });
+  const lock = await safePath(root, ".write-lock");
+  // Never remove another writer's lock, including after a crashed writer.
+  await fs.mkdir(lock).catch((error) => {
+    if (error.code === "EEXIST") throw Error("Another workflow write is active; retry after it finishes. A stale lock requires manual inspection.");
+    throw error;
+  });
+  try { return await operation(); } finally { await fs.rmdir(lock); }
+}

--- a/tests/app-view.test.ts
+++ b/tests/app-view.test.ts
@@ -234,7 +234,7 @@ test("personal module cards keep publisher state, Local state, and thumbnail sta
   detail.closeButton.click();
 });
 
-test("thumbnail, title, and explicit action open candidate details without exact preview", () => {
+test("thumbnail and explicit action open details while title toggles selection locally", () => {
   const window = createTestWindow();
   const document = window.document as unknown as Document;
   const cards = document.createElement("section");
@@ -279,10 +279,11 @@ test("thumbnail, title, and explicit action open candidate details without exact
   );
   (cards.querySelectorAll(".preview-button")[0] as HTMLButtonElement).click();
   (cards.querySelectorAll(".candidate-title")[1] as HTMLButtonElement).click();
+  assert.equal(cards.querySelectorAll(".card")[1]!.classList.contains("is-selected"), true);
+  assert.equal(cards.querySelectorAll(".candidate-title")[1]!.getAttribute("aria-pressed"), "true");
   (cards.querySelectorAll(".candidate-action")[1] as HTMLButtonElement).click();
   assert.deepEqual(opened, [
     { templateId: "local-bar", openerClass: "preview preview-button" },
-    { templateId: "figureya-bar", openerClass: "candidate-title" },
     { templateId: "figureya-bar", openerClass: "candidate-action" },
   ]);
   assert.equal(empty.hidden, true);

--- a/tests/figure-workflow.test.ts
+++ b/tests/figure-workflow.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { unzipSync } from "fflate";
+import { StyleProfileStore } from "../src/style-profile.ts";
+import { ProjectFigures, type ArchiveDetailsValue } from "../src/project-figures.ts";
+import { safeRelative } from "../src/workflow-storage.ts";
+import { digest } from "../src/workflow-storage.ts";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerFigureWorkflowTools } from "../src/figure-workflow-tools.ts";
+import { WorkspaceRuntime } from "../src/workspace-runtime.ts";
+
+async function temp(t: TestContext) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "sfl-workflow-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true })); return root;
+}
+const details: ArchiveDetailsValue = {
+  purpose: "Compare measured values for two example groups", dataDescription: "Synthetic plot data: group and value; no missing values; values in arbitrary units.",
+  scriptDescription: "Read plot-data.csv and generate an SVG bar chart, without upstream analysis.",
+  environment: `Verified in Node ${process.version}; no external dependencies or fonts required.`, parameters: { width: 200, height: 100 },
+  provenanceNotes: "Locally authored synthetic fixture; no original experimental measurements are included.", runCommand: "node scripts/plot.mjs",
+  execution: "succeeded", executionNotes: "Executed locally; SVG bars and dimensions checked.", scope: "Plotting source data and code only; no raw experimental data.",
+  changes: "Initial local fixture revision", externalDependencies: [], originalScript: "none", panelLabelInArtwork: null,
+};
+const script = `import fs from 'node:fs';
+const rows = fs.readFileSync('data/plot-data.csv', 'utf8').trim().split('\\n').slice(1).map(r => r.split(','));
+fs.mkdirSync('outputs', {recursive:true});
+fs.writeFileSync('outputs/plot.svg', '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">' + rows.map((r,i) => '<rect x="'+(i*80+10)+'" y="'+(100-Number(r[1])*10)+'" width="40" height="'+(Number(r[1])*10)+'" fill="#16846a"/>').join('') + '</svg>');
+`;
+const chineseTranslation = {
+  files: [], labels: [], verified: true, notes: "已验证英文代码与当前图标签，科学含义保持不变。",
+  readmeSections: { purpose: "比较两组样本的示例数值。", dataDescription: "人工合成作图数据，包含组名与数值，无缺失值，单位为任意单位。", scriptDescription: "读取作图数据后生成柱状图，不执行上游分析。", environment: `已验证 Node ${process.version}，不需要额外依赖。`, provenanceNotes: "本地创建的合成样例，无原始实验数据。", executionNotes: "已在本地执行，检查了 SVG 尺寸与柱形。", scope: "包含作图数据与代码，不包含原始实验材料。", changes: "首次生成本地样例修订。" },
+  fileDescriptions: { "data/plot-data.csv": "合成分组数值", "scripts/plot.mjs": "实际绘图脚本", "outputs/plot.svg": "已渲染的柱状图" },
+};
+async function fixture(t: TestContext) {
+  const root = await temp(t); const project = new ProjectFigures(root);
+  const plan = await project.plan([{ title: "Example comparison", slug: "example-comparison" }]);
+  const state = await project.apply(plan); const figure = state.figures[0]!; const work = path.join(root, figure.directory);
+  await fs.mkdir(path.join(work, "data")); await fs.mkdir(path.join(work, "scripts"));
+  await fs.writeFile(path.join(work, "data/plot-data.csv"), "group,value\nA,4\nB,7\n");
+  await fs.writeFile(path.join(work, "scripts/plot.mjs"), script);
+  await promisify(execFile)(process.execPath, ["scripts/plot.mjs"], { cwd: work });
+  const artifacts = [
+    { path: "data/plot-data.csv", role: "plot_data" as const, description: "Synthetic group values", source: { kind: "local" as const, reference: "Synthetic fixture created for this project" } },
+    { path: "scripts/plot.mjs", role: "plot_script" as const, description: "Actual plotting script", source: { kind: "generated" as const, reference: "Authored locally for this example" } },
+    { path: "outputs/plot.svg", role: "output" as const, description: "Rendered bar chart", source: { kind: "generated" as const, reference: "scripts/plot.mjs and data/plot-data.csv" } },
+  ];
+  const renderEvidence = { verifiedAt: new Date().toISOString(), files: Object.fromEntries(await Promise.all(artifacts.map(async (a) => [a.path, digest(await fs.readFile(path.join(work, a.path)))]))) };
+  return { root, project, figure, work, artifacts, renderDetails: { ...details, renderEvidence } };
+}
+
+test("style settings survive a new store; current overrides and faithful template take priority", async (t) => {
+  const root = await temp(t); const store = new StyleProfileStore(root);
+  await store.save({ expectedRevision: 0, name: "Lab", settings: { fontFamily: "Arial", colors: { A: "#0000ff", B: "#ff8800" }, size: { width: 85, unit: "mm" }, export: { formats: ["pdf", "png"], rasterDpi: 600 } } });
+  const fresh = new StyleProfileStore(root);
+  const resolved = await fresh.resolve({ fontFamily: "serif" }, { colors: { B: "#aa0000" } });
+  assert.equal(resolved.effective.fontFamily, "Arial"); assert.deepEqual(resolved.effective.colors, { A: "#0000ff", B: "#aa0000" });
+  assert.equal((await fresh.read()).settings.colors!.B, "#ff8800");
+  assert.equal((await fresh.resolve({ fontFamily: "serif" }, {}, true)).effective.fontFamily, "serif");
+  await assert.rejects(fresh.save({ expectedRevision: 0, name: "stale", settings: {} }), /changed/);
+  await assert.rejects(fresh.save({ expectedRevision: 1, name: "invalid", settings: { size: { width: -1, unit: "mm" } } }));
+  await fresh.reset(1); assert.equal((await new StyleProfileStore(root).read()).enabled, false);
+  assert.equal((await fresh.read()).revision, 2);
+});
+
+test("plan eight panels, exchange B/C atomically, find aliases and reject duplicate names and stale writes", async (t) => {
+  const root = await temp(t); const p = new ProjectFigures(root);
+  const state = await p.apply(await p.plan("ABCDEFGH".split("").map((panel) => ({ title: `Panel ${panel}`, label: { figure: 1, panel } }))));
+  assert.equal(state.figures.length, 8); assert.ok(state.figures.every((f) => f.revision === 0));
+  const b = state.figures[1]!; const c = state.figures[2]!;
+  await fs.writeFile(path.join(root, b.directory, "marker.txt"), "B-data");
+  await fs.writeFile(path.join(root, c.directory, "marker.txt"), "C-data");
+  const swap = await p.plan([{ id: b.id, title: b.title, slug: c.slug, label: c.label }, { id: c.id, title: c.title, slug: b.slug, label: b.label }]);
+  await p.apply(swap);
+  assert.equal(await fs.readFile(path.join(root, c.directory, "marker.txt"), "utf8"), "B-data");
+  assert.equal(await fs.readFile(path.join(root, b.directory, "marker.txt"), "utf8"), "C-data");
+  assert.equal((await new ProjectFigures(root).list(b.id)).figures[0]!.label!.panel, "C");
+  assert.equal((await p.list("Figure 1B")).ambiguous, true);
+  await assert.rejects(p.apply(swap), /Stale/);
+  await assert.rejects(p.plan([{ title: "Panel A", slug: state.figures[0]!.slug }]), /conflict/);
+  for (const bad of ["../escape", "CON", "a\\b", "x:stream", "trailing.", "/absolute"]) assert.throws(() => safeRelative(bad));
+});
+
+test("archive ZIP is self contained and reproduces the same figure after unpacking", async (t) => {
+  const { root, project, figure, artifacts, renderDetails } = await fixture(t);
+  const result = await project.archive(figure.id, 0, artifacts, renderDetails);
+  assert.equal(result.complete, true);
+  const translation = { files: [], labels: [], verified: true, notes: "Generated code is English; no artwork labels need translation.", readmeSections: {
+    purpose: details.purpose, dataDescription: details.dataDescription, scriptDescription: details.scriptDescription, environment: details.environment,
+    provenanceNotes: details.provenanceNotes, executionNotes: details.executionNotes, scope: details.scope, changes: details.changes,
+  } };
+  const plan = await project.planExport(figure.id, "en", translation);
+  const exported = await project.applyExport(plan, translation);
+  const unpack = path.join(root, "unpacked"); await fs.mkdir(unpack);
+  const files = unzipSync(await fs.readFile(exported.path));
+  for (const [name, bytes] of Object.entries(files)) { await fs.mkdir(path.dirname(path.join(unpack, name)), { recursive: true }); await fs.writeFile(path.join(unpack, name), bytes); }
+  const before = await fs.readFile(path.join(unpack, "outputs/plot.svg"));
+  await fs.unlink(path.join(unpack, "outputs/plot.svg"));
+  await promisify(execFile)(process.execPath, ["scripts/plot.mjs"], { cwd: unpack });
+  assert.deepEqual(await fs.readFile(path.join(unpack, "outputs/plot.svg")), before);
+  assert.match(Buffer.from(files["README.md"]!).toString(), /Identity and purpose/);
+  assert.equal(JSON.parse(Buffer.from(files["manifest.json"]!).toString()).exportLocale, "en");
+  await assert.rejects(project.applyExport(plan, translation), /EEXIST/);
+  const zh = await project.applyExport(await project.planExport(figure.id, "zh-CN", chineseTranslation), chineseTranslation);
+  assert.notEqual(zh.path, exported.path);
+  assert.match(Buffer.from(unzipSync(await fs.readFile(zh.path))["README.md"]!).toString(), /图的身份与目的/);
+});
+
+test("incomplete renders, unknown sources, tampering and stale language preparation cannot export", async (t) => {
+  const { project, figure, artifacts, work, renderDetails } = await fixture(t);
+  const failed = await project.archive(figure.id, 0, artifacts, { ...details, execution: "failed" });
+  assert.equal(failed.complete, false);
+  const translation = chineseTranslation;
+  await assert.rejects(project.planExport(figure.id, "zh-CN", translation), /incomplete/);
+  const good = await project.archive(figure.id, 1, artifacts, renderDetails);
+  await fs.writeFile(path.join(good.archiveDirectory, "data/plot-data.csv"), "tampered");
+  assert.equal((await project.check(figure.id)).complete, false);
+  await assert.rejects(project.planExport(figure.id, "zh-CN", translation), /Changed file/);
+  await project.archive(figure.id, 2, artifacts, renderDetails);
+  const plan = await project.planExport(figure.id, "zh-CN", translation);
+  await fs.writeFile(path.join(work, "data/plot-data.csv"), "group,value\nA,1\nB,2\n");
+  await assert.rejects(project.archive(figure.id, 3, artifacts, renderDetails), /changed since verified render/);
+  await project.archive(figure.id, 3, artifacts, { ...renderDetails, execution: "not_run" });
+  await assert.rejects(project.applyExport(plan, translation), /incomplete|changed/);
+});
+
+test("renaming a rendered panel preserves its ID and revisions but requires rerendering artwork letters", async (t) => {
+  const { project, figure, artifacts, renderDetails } = await fixture(t);
+  await project.apply(await project.plan([{ id: figure.id, title: figure.title, label: { figure: 1, panel: "B" } }]));
+  await project.archive(figure.id, 0, artifacts, { ...renderDetails, panelLabelInArtwork: "B" });
+  await project.apply(await project.plan([{ id: figure.id, title: "Updated comparison", label: { figure: 2, panel: "C" } }]));
+  const found = (await project.list(figure.id)).figures[0]!;
+  assert.equal(found.id, figure.id); assert.equal(found.history.length, 1);
+  assert.equal(found.artworkLabelPending, true);
+  assert.ok((await project.check(figure.id)).errors.some((e) => e.includes("panel label")));
+});
+
+test("all twelve workflow MCP tools expose terminal outcomes and complete an isolated workflow", async (t) => {
+  const { root, figure, artifacts, renderDetails } = await fixture(t);
+  const server = new McpServer({ name: "workflow-test", version: "1.0.0" });
+  const runtime = new WorkspaceRuntime({ env: { FIGURE_WORKSPACE_DIR: root }, locatorPath: path.join(root, "workspace-locator.json") });
+  registerFigureWorkflowTools(server, runtime, new StyleProfileStore(path.join(root, "user-settings")));
+  const client = new Client({ name: "workflow-client", version: "1.0.0" });
+  const [a, b] = InMemoryTransport.createLinkedPair(); await server.connect(b); await client.connect(a);
+  t.after(async () => { await client.close(); await server.close(); });
+  const called = new Set<string>();
+  async function call(suffix: string, args: Record<string, unknown> = {}) {
+    const name = `figure_library_${suffix}`; called.add(name);
+    const result = await client.callTool({ name, arguments: args });
+    assert.notEqual(result.isError, true, JSON.stringify(result));
+    const data = result.structuredContent as Record<string, unknown>;
+    assert.equal((data.envelope as Record<string, unknown>).terminal, true);
+    return data;
+  }
+  await call("get_style_profile");
+  await call("save_style_profile", { expectedRevision: 0, name: "Lab", settings: { fontFamily: "Arial" } });
+  await call("resolve_style"); await call("reset_style_profile", { expectedRevision: 1 });
+  await call("list_project_figures");
+  const change = await call("plan_project_figures", { changes: [{ title: "Another plot", slug: "another-plot" }] });
+  await call("apply_project_figures", { planDigest: change.digest });
+  await call("archive_project_figure", { figureId: figure.id, expectedRevision: 0, artifacts, details: renderDetails });
+  await call("check_project_figure", { figureId: figure.id });
+  await call("prepare_submission", { figureId: figure.id, locale: "zh-CN", translation: chineseTranslation });
+  const plan = await call("plan_submission_export", { figureId: figure.id, locale: "zh-CN" });
+  await call("apply_submission_export", { planDigest: plan.digest });
+  assert.deepEqual([...called].sort(), (await client.listTools()).tools.map((v) => v.name).sort());
+});
+
+test("rename failure restores both data and index, while concurrent creates cannot share a path", async (t) => {
+  const root = await temp(t); const project = new ProjectFigures(root);
+  const first = await project.apply(await project.plan([{ title: "Original", slug: "original" }]));
+  const figure = first.figures[0]!;
+  await fs.writeFile(path.join(root, figure.directory, "data.txt"), "unchanged");
+  const plan = await project.plan([{ id: figure.id, title: "Renamed", slug: "renamed" }]);
+  await fs.mkdir(path.join(root, "figures/renamed"));
+  await assert.rejects(project.apply(plan), /Destination appeared/);
+  assert.equal((await project.list(figure.id)).figures[0]!.slug, "original");
+  assert.equal(await fs.readFile(path.join(root, figure.directory, "data.txt"), "utf8"), "unchanged");
+  const a = await project.plan([{ title: "Concurrent", slug: "concurrent" }]);
+  const b = await project.plan([{ title: "Concurrent", slug: "concurrent" }]);
+  const results = await Promise.allSettled([project.apply(a), new ProjectFigures(root).apply(b)]);
+  assert.equal(results.filter((r) => r.status === "fulfilled").length, 1);
+  assert.equal((await project.list()).figures.length, 2);
+});
+
+test("missing README, unknown provenance and external local-only dependencies remain incomplete", async (t) => {
+  const { project, figure, artifacts, renderDetails } = await fixture(t);
+  const badSource = artifacts.map((a) => ({ ...a, source: { kind: "unknown" as const, reference: "Unknown origin" } }));
+  let archived = await project.archive(figure.id, 0, badSource, renderDetails);
+  assert.ok(archived.errors.some((e) => e.includes("Unknown source")));
+  archived = await project.archive(figure.id, 1, artifacts, { ...renderDetails, externalDependencies: [{ reference: "project-data/raw.bin", description: "Shared experiment", availability: "local_only" }] });
+  assert.equal(archived.selfContained, false); assert.equal(archived.complete, false);
+  archived = await project.archive(figure.id, 2, artifacts, renderDetails);
+  await fs.unlink(path.join(archived.archiveDirectory, "README.md"));
+  assert.ok((await project.check(figure.id)).errors.some((e) => e.includes("README.md")));
+});
+
+test("working metadata write failure never publishes a new archive revision", async (t) => {
+  const { project, figure, artifacts, renderDetails, work } = await fixture(t);
+  const before = await fs.readFile(path.join(work, "README.md"), "utf8");
+  await fs.mkdir(path.join(work, "environment.txt"));
+  await assert.rejects(project.archive(figure.id, 0, artifacts, renderDetails));
+  assert.equal((await project.list(figure.id)).figures[0]!.revision, 0);
+  assert.equal(await fs.readFile(path.join(work, "README.md"), "utf8"), before);
+});

--- a/tests/server-integration.test.ts
+++ b/tests/server-integration.test.ts
@@ -44,6 +44,18 @@ function toolText(value: unknown) {
 }
 
 const STANDARD_TOOLS = [
+  "figure_library_get_style_profile",
+  "figure_library_save_style_profile",
+  "figure_library_reset_style_profile",
+  "figure_library_resolve_style",
+  "figure_library_list_project_figures",
+  "figure_library_plan_project_figures",
+  "figure_library_apply_project_figures",
+  "figure_library_archive_project_figure",
+  "figure_library_check_project_figure",
+  "figure_library_prepare_submission",
+  "figure_library_plan_submission_export",
+  "figure_library_apply_submission_export",
   "figure_library_apply_adopt_versioning",
   "figure_library_apply_bind_global",
   "figure_library_apply_bind_workspace",
@@ -936,6 +948,19 @@ test("standard server unifies Local Published and FigureYa while hiding Working/
         figure_library_template_history: { templateId: "missing-template" },
       };
       const alreadyAudited = new Set([
+        // Exercised through MCP in figure-workflow.test.ts with isolated user/project stores.
+        "figure_library_get_style_profile",
+        "figure_library_save_style_profile",
+        "figure_library_reset_style_profile",
+        "figure_library_resolve_style",
+        "figure_library_list_project_figures",
+        "figure_library_plan_project_figures",
+        "figure_library_apply_project_figures",
+        "figure_library_archive_project_figure",
+        "figure_library_check_project_figure",
+        "figure_library_prepare_submission",
+        "figure_library_plan_submission_export",
+        "figure_library_apply_submission_export",
         "figure_library_confirm_selection",
         "figure_library_confirm_selection_headless",
         "figure_library_export_diagnostics",

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTestWindow } from "./helpers/dom.ts";
+import { mountPlottingTips, PLOTTING_EXAMPLE } from "../app/plotting-tips.ts";
+import { openSubmissionDialog } from "../app/project-figures.ts";
+
+test("tips restore collapse preference, reopen and copy without submitting a request", async () => {
+  const window = createTestWindow(); const doc = window.document as unknown as Document;
+  const values = new Map([["sfl.plotting-tips.collapsed", "true"]]);
+  let copied = "";
+  const tips = mountPlottingTips(doc, doc.body, {
+    storage: { getItem: (k) => values.get(k) ?? null, setItem: (k, v) => { values.set(k, v); } },
+    copy: async (text) => { copied = text; },
+  });
+  assert.equal(tips.open, false);
+  tips.open = true; tips.dispatchEvent(new window.Event("toggle"));
+  assert.equal(values.get("sfl.plotting-tips.collapsed"), "false");
+  tips.querySelector("button")!.click(); await new Promise((r) => setTimeout(r, 0));
+  assert.equal(copied, PLOTTING_EXAMPLE);
+  assert.match(tips.querySelector('[role="status"]')!.textContent!, /已复制/);
+});
+
+test("tips work when storage and clipboard are unavailable", async () => {
+  const doc = createTestWindow().document as unknown as Document;
+  const tips = mountPlottingTips(doc, doc.body, {
+    storage: { getItem() { throw Error(); }, setItem() { throw Error(); } },
+    copy: async () => { throw Error(); },
+  });
+  tips.querySelector("button")!.click(); await new Promise((r) => setTimeout(r, 0));
+  assert.match(tips.querySelector('[role="status"]')!.textContent!, /手动复制/);
+  assert.equal(tips.querySelector("button")!.disabled, false);
+});
+
+const figure = { id: "figure-fixture", title: "Example", revision: 1, directory: "figures/example", label: null, artworkLabelPending: false };
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("submission dialog requires inventory review, prevents double export and shows failures and success", async () => {
+  const doc = createTestWindow().document as unknown as Document;
+  const opener = doc.createElement("button"); doc.body.append(opener);
+  const calls: Array<{ name: string; input: Record<string, unknown> }> = [];
+  let fail = true; let finish: (v: Record<string, unknown>) => void = () => {};
+  const dialog = openSubmissionDialog(doc, figure, async (name, input) => {
+    calls.push({ name, input });
+    if (name.includes("plan_")) {
+      if (fail) throw Error("Missing language preparation");
+      return { digest: "abc", destination: "exports/example-r1-en.zip", files: [{ path: "README.md", bytes: 100 }], exceptions: [] };
+    }
+    return new Promise((resolve) => { finish = resolve; });
+  }, async () => {}, opener);
+  const buttons = Array.from(dialog.querySelectorAll("button"));
+  const preview = buttons.find((b) => b.textContent === "检查并预览文件清单")!;
+  const submit = buttons.find((b) => b.textContent === "导出")!;
+  const cancel = buttons.find((b) => b.textContent === "取消")!;
+  assert.equal(submit.disabled, true);
+  preview.click(); await tick(); assert.match(dialog.textContent!, /Missing language preparation/);
+  assert.equal(submit.disabled, true); fail = false;
+  const language = dialog.querySelector("select")!; language.value = "en";
+  language.dispatchEvent(new doc.defaultView!.Event("change"));
+  preview.click(); await tick(); assert.match(dialog.textContent!, /README.md/);
+  assert.equal(submit.disabled, false); submit.click(); submit.click();
+  assert.equal(calls.filter((v) => v.name.includes("apply_")).length, 1);
+  assert.equal(cancel.disabled, true);
+  finish({ path: "exports/example-r1-en.zip" }); await tick();
+  assert.match(dialog.textContent!, /已导出：exports/); assert.equal(submit.disabled, true);
+  cancel.click(); assert.equal(doc.querySelector("dialog"), null);
+});
+
+test("cancel and Escape do not export; late preview replies cannot reopen a closed dialog", async () => {
+  const window = createTestWindow(); const doc = window.document as unknown as Document;
+  const opener = doc.createElement("button"); doc.body.append(opener);
+  let calls = 0; let finish: (v: Record<string, unknown>) => void = () => {};
+  const dialog = openSubmissionDialog(doc, figure, async () => { calls++; return new Promise((resolve) => { finish = resolve; }); }, async () => {}, opener);
+  const buttons = Array.from(dialog.querySelectorAll("button"));
+  buttons.find((b) => b.textContent === "检查并预览文件清单")!.click();
+  buttons.find((b) => b.textContent === "取消")!.click();
+  finish({ digest: "late", destination: "unused", files: [], exceptions: [] }); await tick();
+  assert.equal(calls, 1); assert.equal(doc.querySelector("dialog"), null);
+  const second = openSubmissionDialog(doc, figure, async () => { calls++; return {}; }, async () => {}, opener);
+  const cancelEvent = new window.Event("cancel", { cancelable: true });
+  second.dispatchEvent(cancelEvent); assert.equal(cancelEvent.defaultPrevented, false);
+  // Native dialog performs this default action for Escape; jsdom does not.
+  second.close(); assert.equal(calls, 1);
+});


### PR DESCRIPTION
候选图标题点击原先只打开详情，浏览诊断调用还可能触发宿主审批，导致用户无法判断是否已经选中模板。本次增加明确的本地选择反馈，并接入绘图规范持久化、项目图身份管理与可复现归档，让选模板之后的绘图、修改和投稿导出能够跨会话追溯。

Closes #23
Closes #18
Closes #17
Closes #19
Closes #21

本 PR 不包含 #20 用户手册、#22 Logo 或 #15 Workbuddy 适配。

## 改动

- #23：标题和卡片空白处切换选择，增加选中边框、标记和固定计数栏；基础浏览不再发送诊断工具调用，详情保留独立入口。
- #18：提供可折叠的科研绘图提示、自然语言示例和复制按钮，保存折叠偏好，并处理宿主不允许存储或剪贴板访问的情况。
- #17：保存、读取和重置本地用户绘图规范，使用版本检查防止旧配置覆盖新配置；有效设置遵循模板、已启用规范、当次覆盖的优先级，忠实复现模式可绕过长期偏好。
- #19/#21：增加项目图稳定 ID、可选论文图号/面板标签、名称检索与历史别名、批量编号交换、路径冲突检查及失败回滚。每图工作目录关联不可变修订快照，保存实际作图数据、脚本、参数、环境、来源和输出，校验文件哈希及运行证据。
- 投稿导出：增加中文/English 选择弹窗、语言准备交接、文件清单预览、取消和导出状态；重验来源与准备文件，保留原始材料，分别生成不覆盖历史文件的 ZIP，并记录语言、来源修订、导出时间及校验值。
- 新增 12 个 MCP 工具，更新插件自带 Skills 和标准工具清单测试；总计 65 个标准工具。

## 验证

- `npm run build` 通过，包括 TypeScript 检查与 App/服务端构建。
- `node scripts/smoke.mjs` 通过：65 个标准工具、现有模板检索/预览/材料化与工具结果协议正常。
- `npm test`：300 项，299 通过，1 失败。唯一失败为既有 `full backup Apply uses the shared writer lock and rejects recursive targets` 测试：本机 Windows 创建目录符号链接返回 `EPERM`；没有跳过或放宽该测试。
- 新增回归覆盖跨实例读取规范、覆盖优先级、编号交换、并发命名冲突、改名回滚、归档写入失败、文件篡改、缺失来源/材料、过期导出计划、取消及重复点击，以及全部新增 MCP 工具的端到端调用。
- 离线 ZIP 重绘验证通过：解压到新目录后，仅使用包内脚本与数据生成与导出前一致的 SVG。
- 本地浏览器使用测试数据检查了选中反馈、计数栏、深色模式、投稿弹窗和 Escape 取消；尚未在实际 Wisp 宿主中安装验收。

## 实现边界

- SFL 不执行绘图代码或翻译模型。宿主负责应用规范、翻译准备副本、必要的重绘和科学含义检查；代码执行及语言验证明确标为宿主报告，不能仅凭保存配置声称输出已符合要求。
- 主图通过标签进行逻辑分组，不自动拼图。工作目录更名不会自动改写包外绝对路径；图内面板字母变化会标记待重绘。历史归档保持原貌。
- 归档仅收录明确列出的文件，单文件上限 64 MiB、总输入上限 128 MiB。缺失或仅本机可用的包外数据阻止完整投稿导出；已有可获取存档引用仍明确标记为非自包含。
- 普通写入/改名失败会回滚；进程中断留下的写锁和恢复记录需要检查后恢复，不自动抢占锁。投稿 ZIP 不自动上传，也不保证满足所有期刊的原始数据要求。
