### PR TITLE
Make candidate selection obvious with click-to-select and a sticky selection bar

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -16,6 +16,7 @@ import {
 } from "./brand.ts";
 import { createIcon, setButtonContent } from "./icons.ts";
 import {
+  announceSelectionChange,
   openCandidateDetail,
   parseSearchResult,
   renderCandidateCards,
@@ -46,6 +47,7 @@ const pageStatus = document.getElementById("page-status")!;
 const plotSetBar = document.getElementById("plot-set-bar")!;
 const plotSetCount = document.getElementById("plot-set-count")!;
 const plotSetSubmit = document.getElementById("plot-set-submit") as HTMLButtonElement;
+const toastRegion = document.getElementById("toast-region")!;
 const displayControls = document.getElementById("display-controls")!;
 const expandBrowse = document.getElementById("expand-browse") as HTMLButtonElement;
 const keepVisible = document.getElementById("keep-visible") as HTMLButtonElement;
@@ -104,7 +106,7 @@ const reportedCapabilities = new Set<string>();
 const selectedCandidates = new Map<string, Candidate>();
 
 const DEFAULT_TITLE = "选择科学绘图模板";
-const DEFAULT_HINT = "先在这里浏览详情并选择；Agent 会等待你的决定";
+const DEFAULT_HINT = "点击卡片或标题即可勾选；详情用「查看详情」按钮打开";
 const DEFAULT_EMPTY = "请在对话中上传图片或数据，也可以直接描述想画的图。";
 const SETUP_TITLE = "先完成本机绑定";
 const SETUP_HINT = "绑定完成前请先在对话里指定两个绝对目录";
@@ -164,13 +166,14 @@ function selectedIds() {
   return new Set(selectedCandidates.keys());
 }
 
-function refreshPlotSetBar() {
+function refreshPlotSetBar(animateCount = false) {
   renderPlotSetBar({
     bar: plotSetBar,
     submit: plotSetSubmit,
     countLabel: plotSetCount,
     selectedCount: selectedCandidates.size,
     canSubmit: Boolean(activeResult) && updateModelContextAvailable(),
+    animateCount,
   });
 }
 
@@ -207,7 +210,6 @@ function updateModelContextAvailable() {
 async function recordUiEvent(
   event:
     | "host.capabilities_detected"
-    | "candidate.thumbnail_clicked"
     | "candidate.detail_opened"
     | "candidate.detail_closed"
     | "exact_preview.image_loaded"
@@ -264,12 +266,16 @@ function render(result: SearchResult) {
     onToggleSelect: (candidate, selected) => {
       if (selected) selectedCandidates.set(candidate.candidateId, candidate);
       else selectedCandidates.delete(candidate.candidateId);
-      refreshPlotSetBar();
+      refreshPlotSetBar(true);
+      announceSelectionChange({
+        document,
+        region: toastRegion,
+        message: selected
+          ? `已选择「${candidate.title}」，共 ${selectedCandidates.size} 项`
+          : `已取消选择「${candidate.title}」，剩余 ${selectedCandidates.size} 项`,
+      });
     },
-    onDetail: (candidate, elements, opener) => {
-      if (opener === elements.previewButton) {
-        void recordUiEvent("candidate.thumbnail_clicked", candidate);
-      }
+    onDetail: (candidate, _elements, opener) => {
       void recordUiEvent("candidate.detail_opened", candidate);
       activeDetail = openCandidateDetail({
         document,
@@ -291,9 +297,9 @@ function render(result: SearchResult) {
     },
   });
   status.textContent = serverToolsAvailable()
-    ? "请先在 App 内浏览候选详情；只有你请求精确预览并确认后，才会把选择交给 Agent。"
+    ? "点击卡片或标题即可勾选候选。注意：对话中批准 figure_library_record_ui_event 只是允许上报浏览日志，不代表已选择候选；勾选后请点下方「交给 Agent 绘制」。"
     : updateModelContextAvailable()
-      ? "当前 Host 未提供 serverTools；可勾选 1 到 8 个模板交给 Agent 绘制，或打开详情做单张审核。"
+      ? "当前 Host 未提供 serverTools；点击卡片或标题勾选 1 到 8 个模板交给 Agent 绘制，或打开详情做单张审核。"
       : "当前 Host 既未提供 serverTools，也未提供 updateModelContext；只能浏览当前页基础详情。";
   if (result.diagnosticsDegraded) {
     status.textContent += " 诊断日志处于降级状态。";

--- a/app/mcp-app.html
+++ b/app/mcp-app.html
@@ -17,7 +17,7 @@
           </div>
         </div>
         <div class="header-side">
-          <p class="hint">先在这里浏览详情并选择；Agent 会等待你的决定</p>
+          <p class="hint">点击卡片或标题即可勾选；详情用「查看详情」按钮打开</p>
           <div id="display-controls" class="display-controls" hidden>
             <button type="button" id="expand-browse">展开浏览</button>
             <button type="button" id="keep-visible">保持可见</button>
@@ -33,9 +33,10 @@
       </section>
       <section id="cards" class="cards" aria-label="Scientific figure template candidates"></section>
       <section id="plot-set-bar" class="plot-set-bar" aria-label="多选绘图模板">
-        <span id="plot-set-count">已选 0 个模板</span>
+        <span id="plot-set-count" class="plot-set-count">已选 0 个模板</span>
         <button id="plot-set-submit" type="button" disabled>交给 Agent 绘制（0）</button>
       </section>
+      <div id="toast-region" class="toast-region" role="status" aria-live="polite"></div>
       <nav id="pagination" class="pagination" aria-label="候选分页">
         <button id="previous-page" type="button" disabled>上一页</button>
         <span id="page-status">等待搜索结果</span>
@@ -43,7 +44,7 @@
       </nav>
       <footer id="status" aria-live="polite">
         <span id="status-icon" class="status-icon" aria-hidden="true"></span>
-        <span id="status-text">分数只表示召回顺序。打开基础详情不会调用 Agent；可勾选 1 到 8 个模板后点“交给 Agent 绘制”。打开详情不会调用 Agent。</span>
+        <span id="status-text">分数只表示召回顺序。点击卡片或标题即可勾选；打开详情不会调用 Agent。对话中的工具批准只代表允许上报浏览日志，不等于已选择候选。</span>
       </footer>
     </main>
     <script type="module" src="/main.ts"></script>

--- a/app/styles.css
+++ b/app/styles.css
@@ -90,6 +90,7 @@ footer {
 }
 
 .card {
+  position: relative;
   display: flex;
   min-width: 0;
   flex-direction: column;
@@ -98,6 +99,49 @@ footer {
   border-radius: 14px;
   background: var(--color-background-secondary, #fff);
   box-shadow: 0 4px 16px rgb(20 45 32 / 7%);
+  cursor: pointer;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.card:hover:not([data-selected="true"]),
+.card:focus-within:not([data-selected="true"]) {
+  border-color: #7fa893;
+  box-shadow: 0 4px 18px rgb(20 45 32 / 14%);
+}
+
+.card[data-selected="true"] {
+  border-color: transparent;
+  background: #eef7f1;
+  box-shadow:
+    0 0 0 2px var(--sfl-brand-color),
+    0 4px 18px rgb(20 45 32 / 16%);
+}
+
+.select-badge {
+  position: absolute;
+  z-index: 2;
+  top: 10px;
+  right: 10px;
+  display: none;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: var(--sfl-brand-color);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+}
+
+.select-badge .sfl-icon {
+  width: 0.85rem;
+  height: 0.85rem;
+}
+
+.card[data-selected="true"] .select-badge {
+  display: inline-flex;
 }
 
 .preview {
@@ -334,6 +378,15 @@ button:disabled {
 
 button[aria-pressed="true"] {
   background: #17211c;
+}
+
+.candidate-title[aria-pressed="true"] {
+  background: transparent;
+  color: var(--sfl-brand-color-strong);
+}
+
+.empty[hidden] {
+  display: none;
 }
 
 .empty {
@@ -664,28 +717,55 @@ footer {
 }
 
 .candidate-select {
-  display: flex;
+  display: inline-flex;
+  align-self: flex-start;
   align-items: center;
-  gap: 6px;
-  margin: 0 0 8px;
-  font-size: 0.8rem;
-  color: var(--color-text-secondary, #58645d);
+  gap: 8px;
+  width: fit-content;
+  margin: 10px 10px 0;
+  border: 1px solid var(--color-border-primary, #c7d2ca);
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: var(--color-background-secondary, #fff);
+  color: var(--color-text-primary, #17211c);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 700;
+  transition: border-color 140ms ease, color 140ms ease;
+}
+
+.candidate-select:hover,
+.candidate-select:focus-within {
+  border-color: var(--sfl-brand-color);
+  color: var(--sfl-brand-color-strong);
 }
 
 .candidate-select-input {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--sfl-brand-color);
+  cursor: pointer;
 }
 
 .plot-set-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 20;
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 12px;
   margin: 12px 0 0;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: var(--color-background-tertiary, #eef0ed);
+  padding: 12px 14px;
+  border: 1px solid var(--color-border-primary, #d9ddd8);
+  border-radius: 12px;
+  background: var(--color-background-secondary, #fff);
+  box-shadow: 0 10px 28px rgb(20 45 32 / 18%);
+}
+
+.plot-set-bar[data-selected="true"] {
+  border-color: var(--sfl-brand-color);
 }
 
 .plot-set-bar button:disabled {
@@ -694,6 +774,68 @@ footer {
 
 .plot-set-bar button {
   min-width: 0;
+}
+
+.plot-set-count {
+  flex: none;
+  min-width: 0;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.plot-set-count.count-bump {
+  animation: sfl-count-bump 380ms ease;
+}
+
+@keyframes sfl-count-bump {
+  0% {
+    transform: scale(1);
+  }
+
+  40% {
+    transform: scale(1.16);
+    color: var(--sfl-brand-color);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+.toast-region {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 104px;
+  z-index: 60;
+  display: grid;
+  justify-items: center;
+  pointer-events: none;
+}
+
+.selection-toast {
+  max-width: calc(100% - 32px);
+  overflow-wrap: anywhere;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 999px;
+  padding: 9px 16px;
+  background: #17211c;
+  color: #f2f7f4;
+  font-size: 0.8rem;
+  font-weight: 700;
+  box-shadow: 0 12px 30px rgb(10 25 17 / 30%);
+  animation: sfl-toast-in 180ms ease;
+}
+
+@keyframes sfl-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .header-side {
@@ -737,6 +879,10 @@ footer {
 
   .plot-set-bar button {
     width: 100%;
+  }
+
+  .toast-region {
+    bottom: 140px;
   }
 }
 
@@ -791,6 +937,46 @@ footer {
     background: var(--color-background-secondary, #18221c);
   }
 
+  html:not([data-theme]) .card:hover:not([data-selected="true"]),
+  html:not([data-theme]) .card:focus-within:not([data-selected="true"]) {
+    border-color: #5d8270;
+  }
+
+  html:not([data-theme]) .card[data-selected="true"] {
+    background: #17251d;
+    box-shadow:
+      0 0 0 2px #3fae7c,
+      0 4px 18px rgb(0 0 0 / 40%);
+  }
+
+  html:not([data-theme]) .select-badge {
+    background: #2f9c6d;
+  }
+
+  html:not([data-theme]) .candidate-title[aria-pressed="true"] {
+    color: #72d7b1;
+  }
+
+  html:not([data-theme]) .candidate-select:hover,
+  html:not([data-theme]) .candidate-select:focus-within {
+    border-color: #3fae7c;
+    color: #72d7b1;
+  }
+
+  html:not([data-theme]) .plot-set-bar[data-selected="true"] {
+    border-color: #3fae7c;
+  }
+
+  html:not([data-theme]) .plot-set-count.count-bump {
+    animation-name: sfl-count-bump-dark;
+  }
+
+  html:not([data-theme]) .selection-toast {
+    background: #e9f4ee;
+    border-color: rgb(255 255 255 / 20%);
+    color: #142019;
+  }
+
   html:not([data-theme]) .plot-set-bar,
   html:not([data-theme]) .pip-summary,
   html:not([data-theme]) .detail-status {
@@ -839,6 +1025,61 @@ html[data-theme="dark"] {
 html[data-theme="dark"] .card,
 html[data-theme="dark"] .candidate-dialog {
   background: var(--color-background-secondary, #18221c);
+}
+
+html[data-theme="dark"] .card:hover:not([data-selected="true"]),
+html[data-theme="dark"] .card:focus-within:not([data-selected="true"]) {
+  border-color: #5d8270;
+}
+
+html[data-theme="dark"] .card[data-selected="true"] {
+  background: #17251d;
+  box-shadow:
+    0 0 0 2px #3fae7c,
+    0 4px 18px rgb(0 0 0 / 40%);
+}
+
+html[data-theme="dark"] .select-badge {
+  background: #2f9c6d;
+}
+
+html[data-theme="dark"] .candidate-title[aria-pressed="true"] {
+  color: #72d7b1;
+}
+
+html[data-theme="dark"] .candidate-select:hover,
+html[data-theme="dark"] .candidate-select:focus-within {
+  border-color: #3fae7c;
+  color: #72d7b1;
+}
+
+html[data-theme="dark"] .plot-set-bar[data-selected="true"] {
+  border-color: #3fae7c;
+}
+
+html[data-theme="dark"] .plot-set-count.count-bump {
+  animation-name: sfl-count-bump-dark;
+}
+
+html[data-theme="dark"] .selection-toast {
+  background: #e9f4ee;
+  border-color: rgb(255 255 255 / 20%);
+  color: #142019;
+}
+
+@keyframes sfl-count-bump-dark {
+  0% {
+    transform: scale(1);
+  }
+
+  40% {
+    transform: scale(1.16);
+    color: #72d7b1;
+  }
+
+  100% {
+    transform: scale(1);
+  }
 }
 
 html[data-theme="dark"] .plot-set-bar,

--- a/app/view.ts
+++ b/app/view.ts
@@ -355,6 +355,7 @@ export function renderCandidateCards(options: {
   const { document, cards, empty, result } = options;
   cards.replaceChildren();
   empty.hidden = result.candidates.length > 0;
+  const interactiveSelector = "button, input, a, label, summary, select, textarea";
 
   for (const candidate of result.candidates) {
     const card = element(document, "article", "card");
@@ -363,11 +364,11 @@ export function renderCandidateCards(options: {
     const selectBox = document.createElement("input");
     selectBox.type = "checkbox";
     selectBox.className = "candidate-select-input";
-    selectBox.checked = Boolean(options.selectedIds?.has(candidate.candidateId));
     selectBox.setAttribute("aria-label", `选择 ${candidate.title} 交给 Agent 绘制`);
     selectBox.addEventListener("click", (event) => event.stopPropagation());
-    selectBox.addEventListener("change", () => options.onToggleSelect?.(candidate, selectBox.checked));
     selectLabel.append(selectBox, document.createTextNode("选择"));
+    const selectBadge = element(document, "span", "select-badge");
+    selectBadge.append(createIcon(document, "check"), document.createTextNode("已选"));
     const previewButton = button(
       document,
       "preview preview-button",
@@ -385,7 +386,8 @@ export function renderCandidateCards(options: {
     const heading = element(document, "div");
     const headingNode = element(document, "h2", "module");
     const titleButton = button(document, "candidate-title", candidate.title);
-    titleButton.setAttribute("aria-label", `查看 ${candidate.title} 详情`);
+    titleButton.setAttribute("aria-label", `选择 ${candidate.title} 交给 Agent 绘制`);
+    titleButton.title = "点击选择或取消选择；查看详情请用「查看详情」按钮";
     headingNode.append(titleButton);
     heading.append(
       headingNode,
@@ -414,13 +416,36 @@ export function renderCandidateCards(options: {
 
     if (candidate.matchKind) content.append(element(document, "p", "description", "检索分不是重复证明，请对照预览人工确认。"));
     const detailButton = button(document, "candidate-action", "查看详情", "details");
+    const applySelected = (selected: boolean) => {
+      selectBox.checked = selected;
+      card.dataset.selected = selected ? "true" : "false";
+      titleButton.setAttribute("aria-pressed", selected ? "true" : "false");
+    };
+    const toggleSelection = () => {
+      const selected = card.dataset.selected !== "true";
+      applySelected(selected);
+      options.onToggleSelect?.(candidate, selected);
+    };
+    selectBox.addEventListener("change", () => {
+      applySelected(selectBox.checked);
+      options.onToggleSelect?.(candidate, selectBox.checked);
+    });
+    titleButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      toggleSelection();
+    });
+    card.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.closest?.(interactiveSelector)) return;
+      toggleSelection();
+    });
     const elements = { card, previewButton, titleButton, detailButton };
     const open = (opener: HTMLButtonElement) => options.onDetail(candidate, elements, opener);
     previewButton.addEventListener("click", () => open(previewButton));
-    titleButton.addEventListener("click", () => open(titleButton));
     detailButton.addEventListener("click", () => open(detailButton));
     content.append(detailButton);
-    card.append(selectLabel, previewButton, content);
+    applySelected(Boolean(options.selectedIds?.has(candidate.candidateId)));
+    card.append(selectLabel, selectBadge, previewButton, content);
     cards.append(card);
   }
 }
@@ -589,14 +614,33 @@ export function renderPlotSetBar(options: {
   countLabel: HTMLElement;
   selectedCount: number;
   canSubmit: boolean;
+  animateCount?: boolean;
 }) {
   const { bar, submit, countLabel, selectedCount, canSubmit } = options;
   bar.hidden = false;
+  bar.dataset.selected = selectedCount > 0 ? "true" : "false";
   countLabel.textContent = `已选 ${selectedCount} 个模板`;
+  countLabel.classList.remove("count-bump");
+  if (options.animateCount) {
+    void countLabel.offsetWidth;
+    countLabel.classList.add("count-bump");
+  }
   submit.disabled = !canSubmit || selectedCount < 1 || selectedCount > 8;
   setButtonContent(
     submit,
     selectedCount > 8 ? "warning" : "send",
     selectedCount > 8 ? "最多选择 8 个模板" : `交给 Agent 绘制（${selectedCount}）`,
   );
+}
+
+export function announceSelectionChange(options: {
+  document: Document;
+  region: HTMLElement;
+  message: string;
+  durationMs?: number;
+}) {
+  const toast = element(options.document, "div", "selection-toast", options.message);
+  options.region.replaceChildren(toast);
+  options.document.defaultView?.setTimeout(() => toast.remove(), options.durationMs ?? 2400);
+  return toast;
 }

--- a/tests/app-view.test.ts
+++ b/tests/app-view.test.ts
@@ -9,10 +9,12 @@ import {
   updateModelContextForHeadlessReview,
 } from "../app/handoff.ts";
 import {
+  announceSelectionChange,
   mountExactPreviewImage,
   openCandidateDetail,
   parseSearchResult,
   renderCandidateCards,
+  renderPlotSetBar,
   type Candidate,
   type SearchResult,
 } from "../app/view.ts";
@@ -234,7 +236,7 @@ test("personal module cards keep publisher state, Local state, and thumbnail sta
   detail.closeButton.click();
 });
 
-test("thumbnail, title, and explicit action open candidate details without exact preview", () => {
+test("thumbnail and explicit action open candidate details while the title toggles selection", () => {
   const window = createTestWindow();
   const document = window.document as unknown as Document;
   const cards = document.createElement("section");
@@ -245,11 +247,15 @@ test("thumbnail, title, and explicit action open candidate details without exact
     candidate("org.figureya.module", "figureya-bar", "ready", dataUrl),
   ]);
   const opened: Array<{ templateId: string; openerClass: string }> = [];
+  const toggles: Array<{ templateId: string; selected: boolean }> = [];
   renderCandidateCards({
     document,
     cards,
     empty,
     result,
+    onToggleSelect(value, selected) {
+      toggles.push({ templateId: value.templateId, selected });
+    },
     onDetail(value, _elements, opener) {
       opened.push({ templateId: value.templateId, openerClass: opener.className });
     },
@@ -278,14 +284,108 @@ test("thumbnail, title, and explicit action open candidate details without exact
     ),
   );
   (cards.querySelectorAll(".preview-button")[0] as HTMLButtonElement).click();
-  (cards.querySelectorAll(".candidate-title")[1] as HTMLButtonElement).click();
   (cards.querySelectorAll(".candidate-action")[1] as HTMLButtonElement).click();
   assert.deepEqual(opened, [
     { templateId: "local-bar", openerClass: "preview preview-button" },
-    { templateId: "figureya-bar", openerClass: "candidate-title" },
     { templateId: "figureya-bar", openerClass: "candidate-action" },
   ]);
+  (cards.querySelectorAll(".candidate-title")[1] as HTMLButtonElement).click();
+  assert.deepEqual(toggles, [{ templateId: "figureya-bar", selected: true }]);
+  assert.equal(opened.length, 2);
   assert.equal(empty.hidden, true);
+});
+
+test("selection is visible on the card and title or blank-area clicks toggle it", () => {
+  const window = createTestWindow();
+  const document = window.document as unknown as Document;
+  const cards = document.createElement("section");
+  const empty = document.createElement("section");
+  const result = searchResult([
+    candidate("org.scientificfigurelibrary.local", "select-a", "ready"),
+    candidate("org.figureya.module", "select-b", "ready"),
+  ]);
+  const toggles: Array<{ templateId: string; selected: boolean }> = [];
+  let detailsOpened = 0;
+  renderCandidateCards({
+    document,
+    cards,
+    empty,
+    result,
+    selectedIds: new Set(["candidate-select-a"]),
+    onToggleSelect(value, selected) {
+      toggles.push({ templateId: value.templateId, selected });
+    },
+    onDetail() {
+      detailsOpened += 1;
+    },
+  });
+
+  const first = cards.querySelectorAll(".card")[0] as HTMLElement;
+  assert.equal(first.dataset.selected, "true");
+  assert.equal(
+    (first.querySelector(".candidate-select-input") as HTMLInputElement).checked,
+    true,
+  );
+  assert.equal(
+    (first.querySelector(".candidate-title") as HTMLButtonElement).getAttribute("aria-pressed"),
+    "true",
+  );
+  assert.match(first.querySelector(".select-badge")?.textContent ?? "", /已选/u);
+
+  const second = cards.querySelectorAll(".card")[1] as HTMLElement;
+  assert.equal(second.dataset.selected, "false");
+  (second.querySelector(".description") as HTMLElement).click();
+  assert.deepEqual(toggles, [{ templateId: "select-b", selected: true }]);
+  assert.equal(second.dataset.selected, "true");
+  assert.equal(
+    (second.querySelector(".candidate-select-input") as HTMLInputElement).checked,
+    true,
+  );
+  (second.querySelector(".candidate-title") as HTMLButtonElement).click();
+  assert.deepEqual(toggles[1], { templateId: "select-b", selected: false });
+  assert.equal(second.dataset.selected, "false");
+  assert.equal(
+    (second.querySelector(".candidate-select-input") as HTMLInputElement).checked,
+    false,
+  );
+
+  (second.querySelector(".candidate-action") as HTMLButtonElement).click();
+  (second.querySelector(".preview-button") as HTMLButtonElement).click();
+  assert.equal(detailsOpened, 2);
+  assert.equal(toggles.length, 2);
+});
+
+test("selection changes announce a toast and bump the sticky selection count", () => {
+  const window = createTestWindow();
+  const document = window.document as unknown as Document;
+  const region = document.createElement("div");
+  const toast = announceSelectionChange({
+    document,
+    region,
+    message: "已选择「Foo 图」，共 1 项",
+  });
+  assert.equal(region.querySelector(".selection-toast"), toast);
+  assert.equal(toast.textContent, "已选择「Foo 图」，共 1 项");
+
+  const bar = document.createElement("section");
+  const submit = document.createElement("button");
+  const countLabel = document.createElement("span");
+  renderPlotSetBar({
+    bar,
+    submit,
+    countLabel,
+    selectedCount: 1,
+    canSubmit: true,
+    animateCount: true,
+  });
+  assert.equal(countLabel.textContent, "已选 1 个模板");
+  assert.ok(countLabel.classList.contains("count-bump"));
+  assert.equal(bar.dataset.selected, "true");
+  assert.equal(submit.disabled, false);
+  renderPlotSetBar({ bar, submit, countLabel, selectedCount: 0, canSubmit: true });
+  assert.equal(countLabel.classList.contains("count-bump"), false);
+  assert.equal(bar.dataset.selected, "false");
+  assert.equal(submit.disabled, true);
 });
 
 test("basic detail remains available without serverTools and exposes complete metadata", async () => {


### PR DESCRIPTION
Closes #23

## 问题

在 Wisp Science 里浏览候选图时，「选择候选」这件事几乎不可见：勾选框小、位于卡片顶部不醒目；点击卡片只会打开详情；每次点击还会触发 `figure_library_record_ui_event` 审批弹窗，批准后界面毫无变化，很容易把「批准工具调用」误当成「已完成选择」。

## 改动（对应 issue 的五点期望）

1. **强化选中反馈**：勾选框加大到 18px 并使用品牌色 accent-color；勾选控件做成醒目胶囊；卡片选中后显示品牌色描边 + 浅绿底色 + 右上角「✓已选」角标（暗色主题有对应配色）。顺带修了选中标题会套用通用 `button[aria-pressed="true"]` 黑底样式导致不可读的问题。
2. **集中展示已选**：`plot-set-bar` 改为 `position: sticky; bottom: 0`，长列表滚动时「已选 N 个模板」与「交给 Agent 绘制」入口始终可见；有选中时边框高亮；计数变化时播放一次 bump 动画。顺带修复 `.empty[hidden]` 被自身 `display: grid` 覆盖、空状态框在列表渲染后仍然显示的存量问题。
3. **点击即选择**：点击候选标题或卡片空白区域等同于勾选（`aria-pressed` 同步），详情入口由独立的「查看详情」按钮和缩略图按钮承担；按钮/输入等交互元素上的点击不会误触发勾选。
4. **区分两类确认**：点击缩略图不再同时上报 `candidate.thumbnail_clicked` 与 `candidate.detail_opened`（一次点击只触发一次审批）；页脚与状态栏文案明确说明「批准 figure_library_record_ui_event 只是允许上报浏览日志，不代表已选择候选」。
5. **状态变化有反馈**：每次选中/取消都会弹出轻量 toast（「已选择「…」，共 N 项」），toast 遵循 `prefers-reduced-motion`，并已避开 sticky 栏与移动端布局。

## 测试

- `tests/app-view.test.ts`：更新标题点击的行为断言，新增「卡片/标题点击切换选中且选中状态可见」「toast + sticky 计数 bump」等用例；app-view 17/17 通过。
- `tsc --noEmit && vite build` 通过。
- 本地 vite + 浏览器实测亮色/暗色两套主题的选中态、角标、sticky 栏与 toast（见下方截图）。

## 截图

亮色（选中 2 项：描边卡片、「已选」角标、sticky 已选栏、toast）与暗色主题均已人工验证；完整测试套件在本机有 12 个与服务端相关的存量失败，已在干净的 e6645a8 工作树复现，与本 PR 无关。