### PR TITLE
fix: 聚焦模板选择反馈与轻量绘图提示

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -34,6 +34,14 @@ import {
   type WorkbenchDisplayMode,
 } from "./display-mode.ts";
 import "./styles.css";
+import { mountPlottingTips } from "./plotting-tips.ts";
+
+let preferenceStorage: Storage | undefined;
+try { preferenceStorage = window.localStorage; } catch { /* Embedded host may deny storage. */ }
+mountPlottingTips(document, document.getElementById("plotting-help")!, {
+  storage: preferenceStorage,
+  copy: (text) => navigator.clipboard.writeText(text),
+});
 
 const root = document.getElementById("app")!;
 const cards = document.getElementById("cards")!;
@@ -100,7 +108,6 @@ let activeResult: SearchResult | undefined;
 let activeResultSetId: string | undefined;
 let activeDetail: DetailViewElements | undefined;
 const pageCache = new Map<number, SearchResult>();
-const reportedCapabilities = new Set<string>();
 const selectedCandidates = new Map<string, Candidate>();
 
 const DEFAULT_TITLE = "选择科学绘图模板";
@@ -267,10 +274,6 @@ function render(result: SearchResult) {
       refreshPlotSetBar();
     },
     onDetail: (candidate, elements, opener) => {
-      if (opener === elements.previewButton) {
-        void recordUiEvent("candidate.thumbnail_clicked", candidate);
-      }
-      void recordUiEvent("candidate.detail_opened", candidate);
       activeDetail = openCandidateDetail({
         document,
         candidate,
@@ -282,7 +285,6 @@ function render(result: SearchResult) {
           if (result.isError) throw new Error("Host could not open documentation link");
         },
         onClosed: () => {
-          void recordUiEvent("candidate.detail_closed", candidate);
           activeDetail = undefined;
         },
         onRequestExactPreview: (detail) => void loadExactPreview(candidate, detail),
@@ -291,19 +293,14 @@ function render(result: SearchResult) {
     },
   });
   status.textContent = serverToolsAvailable()
-    ? "请先在 App 内浏览候选详情；只有你请求精确预览并确认后，才会把选择交给 Agent。"
+    ? "点击标题或空白处选择，查看详情用于浏览。以已选标记和计数为准；工具审批不代表已选模板。"
     : updateModelContextAvailable()
       ? "当前 Host 未提供 serverTools；可勾选 1 到 8 个模板交给 Agent 绘制，或打开详情做单张审核。"
       : "当前 Host 既未提供 serverTools，也未提供 updateModelContext；只能浏览当前页基础详情。";
   if (result.diagnosticsDegraded) {
     status.textContent += " 诊断日志处于降级状态。";
   }
-  const first = result.candidates[0];
   refreshPlotSetBar();
-  if (first && !reportedCapabilities.has(result.resultSetId) && serverToolsAvailable()) {
-    reportedCapabilities.add(result.resultSetId);
-    void recordUiEvent("host.capabilities_detected", first);
-  }
 }
 
 async function submitPlotSet() {

--- a/app/mcp-app.html
+++ b/app/mcp-app.html
@@ -26,6 +26,7 @@
         </div>
       </header>
       <p id="pip-summary" class="pip-summary" hidden></p>
+      <section id="plotting-help" aria-label="绘图提示"></section>
 
       <section id="empty" class="empty" aria-live="polite">
         <span id="empty-icon" class="state-icon" aria-hidden="true"></span>
@@ -33,7 +34,7 @@
       </section>
       <section id="cards" class="cards" aria-label="Scientific figure template candidates"></section>
       <section id="plot-set-bar" class="plot-set-bar" aria-label="多选绘图模板">
-        <span id="plot-set-count">已选 0 个模板</span>
+        <span id="plot-set-count" role="status" aria-live="polite" aria-atomic="true">已选 0 个模板</span>
         <button id="plot-set-submit" type="button" disabled>交给 Agent 绘制（0）</button>
       </section>
       <nav id="pagination" class="pagination" aria-label="候选分页">
@@ -43,7 +44,7 @@
       </nav>
       <footer id="status" aria-live="polite">
         <span id="status-icon" class="status-icon" aria-hidden="true"></span>
-        <span id="status-text">分数只表示召回顺序。打开基础详情不会调用 Agent；可勾选 1 到 8 个模板后点“交给 Agent 绘制”。打开详情不会调用 Agent。</span>
+        <span id="status-text">点击标题或卡片空白处选择模板，“查看详情”用于浏览。工具运行审批不代表模板已选中；请以“已选”标记和计数为准。</span>
       </footer>
     </main>
     <script type="module" src="/main.ts"></script>

--- a/app/plotting-tips.ts
+++ b/app/plotting-tips.ts
@@ -1,0 +1,37 @@
+export const PLOTTING_EXAMPLE = "使用已选模板和这份数据，生成用于 A4 PPT 拼版的子图，宽 85 mm，统一 Arial，同组同色；导出 PDF 和 600 DPI PNG，并检查文字重叠、裁切和字体是否生效。其他样式保留模板设置。";
+
+export function mountPlottingTips(document: Document, parent: HTMLElement, options: {
+  storage?: Pick<Storage, "getItem" | "setItem">;
+  copy: (text: string) => Promise<void>;
+}) {
+  const tips = document.createElement("details");
+  tips.className = "plotting-tips";
+  let collapsed = false;
+  try { collapsed = options.storage?.getItem("sfl.plotting-tips.collapsed") === "true"; } catch { /* Restricted host storage. */ }
+  tips.open = !collapsed;
+  const summary = document.createElement("summary");
+  summary.textContent = "科研绘图提示 · 自然语言就能表达需求";
+  tips.append(summary);
+  for (const text of [
+    "可以告诉模型：图的用途或期刊要求、数据文件与列名、分组及单位、最终宽高（mm/cm）、字体字号、分组配色、线宽、输出格式与 DPI。可提供参考图；没有特殊要求可沿用模板，不必一次填齐。",
+    "按最终放置尺寸出图，同一实验组跨图保持同色。请说明线宽指坐标轴、图例框还是整图外框。示例数值不是通用投稿标准，不能为了美观改变数据或统计含义。",
+    "字体需检查是否安装；导出格式取决于绘图后端。PDF/SVG 矢量内容与 PNG 栅格 DPI 不同，提高低分辨率图片的 DPI 数值不会增加细节。交付前检查文字裁切、重叠、图例颜色和单位。",
+    "选择模板只在本界面标记；宿主的工具运行审批不代表已选模板。确认已选计数后，点击“交给 Agent 绘制”。",
+  ]) {
+    const paragraph = document.createElement("p"); paragraph.textContent = text; tips.append(paragraph);
+  }
+  const example = document.createElement("blockquote"); example.textContent = PLOTTING_EXAMPLE;
+  const copy = document.createElement("button"); copy.type = "button"; copy.textContent = "复制示例";
+  const status = document.createElement("span"); status.setAttribute("role", "status");
+  copy.addEventListener("click", async () => {
+    copy.disabled = true;
+    try { await options.copy(PLOTTING_EXAMPLE); status.textContent = "已复制，可在对话中修改后使用。"; }
+    catch { status.textContent = "无法访问剪贴板，请选中上方示例手动复制。"; }
+    finally { copy.disabled = false; }
+  });
+  tips.addEventListener("toggle", () => {
+    try { options.storage?.setItem("sfl.plotting-tips.collapsed", String(!tips.open)); } catch { /* Optional preference. */ }
+  });
+  tips.append(example, copy, status); parent.append(tips);
+  return tips;
+}

--- a/app/styles.css
+++ b/app/styles.css
@@ -204,8 +204,8 @@ footer {
 .candidate-title:hover:not(:disabled),
 .candidate-title:focus-visible:not(:disabled) {
   background: transparent;
-  color: #1d6849;
-  outline: 2px solid currentColor;
+  color: inherit;
+  outline: 2px solid #58b79d;
   outline-offset: 2px;
 }
 
@@ -694,7 +694,10 @@ footer {
 
 .plot-set-bar button {
   min-width: 0;
+  width: auto;
 }
+
+.plot-set-bar > span { flex-shrink: 0; white-space: nowrap; }
 
 .header-side {
   display: grid;
@@ -886,3 +889,16 @@ html[data-theme="dark"] .warning-list {
     justify-content: flex-start;
   }
 }
+
+.card { cursor: pointer; }
+.card.is-selected { border: 2px solid #229577; box-shadow: 0 0 0 2px #22957733; }
+.card:hover { outline: 1px solid #22957788; }
+.candidate-select { font-weight: 700; font-size: .95rem; padding: 8px; }
+.candidate-select-input { width: 24px; height: 24px; accent-color: #16846a; }
+.is-selected .candidate-select { color: var(--color-text-primary, #16644f); background: #22957722; border-radius: 6px; }
+.plot-set-bar { position: sticky; bottom: 8px; z-index: 5; border: 1px solid #22957766; box-shadow: 0 4px 20px #0002; }
+.plotting-tips { margin: 14px 0; padding: 14px; border: 1px solid #22957755; border-radius: 10px; }
+.plotting-tips summary { cursor: pointer; font-weight: 700; }
+.plotting-tips p { line-height: 1.65; }
+.plotting-tips blockquote { margin: 12px 0; padding-left: 14px; border-left: 3px solid #229577; }
+#app[data-display-mode="pip"] .plotting-tips { display: none; }

--- a/app/view.ts
+++ b/app/view.ts
@@ -366,8 +366,8 @@ export function renderCandidateCards(options: {
     selectBox.checked = Boolean(options.selectedIds?.has(candidate.candidateId));
     selectBox.setAttribute("aria-label", `选择 ${candidate.title} 交给 Agent 绘制`);
     selectBox.addEventListener("click", (event) => event.stopPropagation());
-    selectBox.addEventListener("change", () => options.onToggleSelect?.(candidate, selectBox.checked));
-    selectLabel.append(selectBox, document.createTextNode("选择"));
+    const selectionText = element(document, "span");
+    selectLabel.append(selectBox, selectionText);
     const previewButton = button(
       document,
       "preview preview-button",
@@ -385,7 +385,26 @@ export function renderCandidateCards(options: {
     const heading = element(document, "div");
     const headingNode = element(document, "h2", "module");
     const titleButton = button(document, "candidate-title", candidate.title);
-    titleButton.setAttribute("aria-label", `查看 ${candidate.title} 详情`);
+    titleButton.setAttribute("aria-label", `选择 ${candidate.title}`);
+    const syncSelection = () => {
+      card.classList.toggle("is-selected", selectBox.checked);
+      titleButton.setAttribute("aria-pressed", String(selectBox.checked));
+      selectionText.textContent = selectBox.checked ? "✓ 已选" : "选择此模板";
+    };
+    const toggleSelection = () => {
+      selectBox.checked = !selectBox.checked;
+      syncSelection();
+      options.onToggleSelect?.(candidate, selectBox.checked);
+    };
+    selectBox.addEventListener("change", () => {
+      syncSelection();
+      options.onToggleSelect?.(candidate, selectBox.checked);
+    });
+    card.addEventListener("click", (event) => {
+      const target = event.target as Element;
+      if (!target.closest("button, input, label, a")) toggleSelection();
+    });
+    syncSelection();
     headingNode.append(titleButton);
     heading.append(
       headingNode,
@@ -417,7 +436,7 @@ export function renderCandidateCards(options: {
     const elements = { card, previewButton, titleButton, detailButton };
     const open = (opener: HTMLButtonElement) => options.onDetail(candidate, elements, opener);
     previewButton.addEventListener("click", () => open(previewButton));
-    titleButton.addEventListener("click", () => open(titleButton));
+    titleButton.addEventListener("click", toggleSelection);
     detailButton.addEventListener("click", () => open(detailButton));
     content.append(detailButton);
     card.append(selectLabel, previewButton, content);

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -444,7 +444,9 @@ claim of complete reproduction.
 
 The MCP App paginates all matched candidates through App-only
 `figure_library_search_page` and renders each usable candidate as a real
-lazy-loaded `<img>`. Clicking the thumbnail, title, or **查看详情** opens an
+lazy-loaded `<img>`. Clicking a title or non-interactive card area toggles local
+selection with a visible marker and count; it does not create a preview receipt
+or authorize materialization. Clicking the thumbnail or **查看详情** opens an
 accessible dialog with a larger candidate image, the complete description,
 and only metadata actually present in the search result. This basic detail is
 fully local to the App: it works without `serverTools`, does not call the

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -67,6 +67,8 @@ Three parties are involved; for every step, ask who does it:
   `template.lock.json` is written
 - Portable backup / restore / fork (bundle export / full restore)
 
+Collapsible plotting tips and a copyable example help express current-task requirements without a mandatory form or persistent style settings. More examples are in [section 6](#6-fonts-colors-sizes-and-export).
+
 **What SFL does not do (✅ boundaries are equally implemented):**
 
 - It **never executes plotting code** and contains no second model;
@@ -87,9 +89,6 @@ figure-style) guide those behaviors; see [section 9](#9-advanced-reference).
 - [#17](https://github.com/xuzhougeng/ScientificFigureLibrary/issues/17): persist
   a user style profile and apply it automatically in later sessions — today
   font/color preferences last only for the current session
-- [#18](https://github.com/xuzhougeng/ScientificFigureLibrary/issues/18): a
-  user-visible plotting tips card with requirement examples — for now use the
-  prompts in [section 6](#6-fonts-colors-sizes-and-export)
 - [#19](https://github.com/xuzhougeng/ScientificFigureLibrary/issues/19): enforce
   one-figure-one-folder archiving and submission packaging by default — today
   the host model organizes folders on request only, see
@@ -149,6 +148,8 @@ an admin override only; daily use does not need it.
 The core discipline is **view the real preview, explicitly confirm that card,
 then materialize**. Materialization copies the confirmed template into the
 project; it does not execute code.
+
+Click a title or empty card area to select or deselect; use the selected marker and count as feedback. Thumbnails and **查看详情** open details. Basic detail browsing emits no diagnostic tool calls. Neither a selection checkbox nor a host tool approval is an exact-preview confirmation or permission to materialize or execute code.
 
 | Step | Who | What you need to know |
 | --- | --- | --- |

--- a/docs/USER_GUIDE.zh-CN.md
+++ b/docs/USER_GUIDE.zh-CN.md
@@ -51,6 +51,7 @@ SFL 是一个**本机优先**的 stdio MCP 服务器加 MCP App。它把你的�
 - 维护本机**一份全局 Library**,一个用户选定的目录,跨项目、跨宿主共享
 - 图+代码的**直接导入**:不可变 Revision、审阅记录与 Release
 - MCP App 画廊:浏览、精确预览、用户确认后才继续
+- 可折叠的科研绘图提示与复制示例:帮助表达当次需求,不保存长期样式、不要求填写参数表;更多示例见[第 6 节](#6-字体配色尺寸与导出调整)
 - 统一检索,默认顺序:**Local Published → FigureYa → Open Figure Modules(内置目录或已验证更新目录) → 已启用并显式参与默认搜索的动态个人 Provider**;Community 快照已冻结,不参与默认搜索
 - **精确物化(materialize)**:把你确认的那一个模板复制进项目,目标目录永不覆盖,并写入 `template.lock.json`
 - 便携备份/恢复/分叉(bundle export / full restore)
@@ -69,7 +70,6 @@ SFL 是一个**本机优先**的 stdio MCP 服务器加 MCP App。它把你的�
 **规划中(🕓,截至本手册编写时均未实现):**
 
 - [#17](https://github.com/xuzhougeng/ScientificFigureLibrary/issues/17):持久保存用户绘图规范(style profile)并在后续会话自动应用——当前字体、配色等偏好只在你当次会话内有效
-- [#18](https://github.com/xuzhougeng/ScientificFigureLibrary/issues/18):用户可见的科研绘图提示与需求表达示例——目前请参考本手册[第 6 节](#6-字体配色尺寸与导出调整)的提问示例
 - [#19](https://github.com/xuzhougeng/ScientificFigureLibrary/issues/19):默认落实"一图一文件夹"归档与投稿打包——当前由宿主模型按你的要求临时组织,见[第 7 节](#7-输出查看与重绘)
 
 ---
@@ -121,6 +121,8 @@ Claude Science、Codex、Claude Code、Cursor 等)。
 
 SFL 的核心纪律是:**先看真实预览,由你确认那一张卡,然后才物化**。
 物化(materialize)是把确认的模板文件复制到项目,不是运行代码。
+
+点击标题或卡片空白处可选择/取消选择,以“已选”标记和计数为准;缩略图和“查看详情”用于浏览。基础详情不触发诊断工具调用。勾选和宿主工具审批都不等于精确预览确认,也不自动授权物化或执行绘图。
 
 | 步骤 | 谁做 | 你需要知道什么 |
 | --- | --- | --- |

--- a/skills/figure-library/SKILL.md
+++ b/skills/figure-library/SKILL.md
@@ -412,8 +412,10 @@ complete result set by default.
 The search result keeps model-visible `structuredContent` compact and carries
 verified thumbnail Data URLs only in result `_meta`, which is component-only.
 The App merges those thumbnails by result-scoped `candidateId`; do not ask the
-Agent to parse Base64. Each thumbnail, title, and **查看详情** action opens an
-accessible dialog using metadata already returned by search. Basic detail must
+Agent to parse Base64. Clicking a title or non-interactive card area toggles
+local selection; the selected marker and count are not tool approvals or preview
+receipts. Each thumbnail and **查看详情** action opens an accessible dialog using
+metadata already returned by search. Basic detail must
 remain usable without `serverTools` and must not call the Agent or a Server
 Tool. Candidates whose preview is missing, unreadable, unsupported,
 path-invalid, corrupt, or over the transfer limit remain visible with an error

--- a/tests/app-view.test.ts
+++ b/tests/app-view.test.ts
@@ -234,7 +234,7 @@ test("personal module cards keep publisher state, Local state, and thumbnail sta
   detail.closeButton.click();
 });
 
-test("thumbnail, title, and explicit action open candidate details without exact preview", () => {
+test("thumbnail and explicit action open details while title toggles selection locally", () => {
   const window = createTestWindow();
   const document = window.document as unknown as Document;
   const cards = document.createElement("section");
@@ -279,10 +279,11 @@ test("thumbnail, title, and explicit action open candidate details without exact
   );
   (cards.querySelectorAll(".preview-button")[0] as HTMLButtonElement).click();
   (cards.querySelectorAll(".candidate-title")[1] as HTMLButtonElement).click();
+  assert.equal(cards.querySelectorAll(".card")[1]!.classList.contains("is-selected"), true);
+  assert.equal(cards.querySelectorAll(".candidate-title")[1]!.getAttribute("aria-pressed"), "true");
   (cards.querySelectorAll(".candidate-action")[1] as HTMLButtonElement).click();
   assert.deepEqual(opened, [
     { templateId: "local-bar", openerClass: "preview preview-button" },
-    { templateId: "figureya-bar", openerClass: "candidate-title" },
     { templateId: "figureya-bar", openerClass: "candidate-action" },
   ]);
   assert.equal(empty.hidden, true);
@@ -690,4 +691,65 @@ test("legacy scenarios render once and absent scenarios never use visualProfile"
   assert.match(detail.dialog.textContent ?? "", /未单独记录/u);
   assert.doesNotMatch(detail.dialog.textContent ?? "", /Red points/u);
   detail.closeButton.click();
+});
+
+test("selection toggles locally once and survives rerender; detail controls do not select", () => {
+  const window = createTestWindow();
+  const document = window.document as unknown as Document;
+  const cards = document.createElement("section");
+  const empty = document.createElement("section");
+  document.body.append(cards, empty);
+  const item = candidate("org.figureya.module", "selection", "ready", "data:image/png;base64,iVBORw0KGgo=");
+  const selected = new Set<string>();
+  const toggles: boolean[] = [];
+  let details = 0;
+  const render = () => renderCandidateCards({
+    document, cards, empty, result: searchResult([item]), selectedIds: selected,
+    onToggleSelect(value, checked) {
+      toggles.push(checked);
+      if (checked) selected.add(value.candidateId); else selected.delete(value.candidateId);
+    },
+    onDetail() { details++; },
+  });
+  const card = () => cards.querySelector(".card") as HTMLElement;
+  const title = () => cards.querySelector(".candidate-title") as HTMLButtonElement;
+  const checkbox = () => cards.querySelector(".candidate-select-input") as HTMLInputElement;
+  render();
+  title().click();
+  assert.deepEqual(toggles, [true]);
+  assert.equal(card().classList.contains("is-selected"), true);
+  assert.equal(title().getAttribute("aria-pressed"), "true");
+  assert.match(cards.querySelector(".candidate-select")!.textContent!, /已选/);
+  render();
+  assert.equal(checkbox().checked, true);
+  assert.equal(card().classList.contains("is-selected"), true);
+  assert.equal(title().getAttribute("aria-pressed"), "true");
+  (cards.querySelector(".preview-button") as HTMLButtonElement).click();
+  (cards.querySelector(".candidate-action") as HTMLButtonElement).click();
+  assert.equal(details, 2);
+  assert.deepEqual(toggles, [true]);
+  card().click();
+  assert.deepEqual(toggles, [true, false]);
+  assert.equal(checkbox().checked, false);
+  checkbox().click();
+  assert.deepEqual(toggles, [true, false, true]);
+  (cards.querySelector(".candidate-select") as HTMLLabelElement).click();
+  assert.deepEqual(toggles, [true, false, true, false]);
+  const link = document.createElement("a");
+  link.textContent = "source";
+  card().append(link);
+  link.click();
+  assert.deepEqual(toggles, [true, false, true, false]);
+  assert.equal(title().getAttribute("aria-pressed"), "false");
+});
+
+test("basic browsing no longer emits diagnostic calls and retains exact-preview diagnostics", () => {
+  const main = fs.readFileSync(path.join(import.meta.dirname, "../app/main.ts"), "utf8");
+  assert.doesNotMatch(main, /recordUiEvent\("(?:candidate\.(?:thumbnail_clicked|detail_opened|detail_closed)|host\.capabilities_detected)"/);
+  assert.match(main, /recordUiEvent\("exact_preview\.image_loaded"/);
+  assert.match(main, /recordUiEvent\("model_context\.updated"/);
+  const html = fs.readFileSync(path.join(import.meta.dirname, "../app/mcp-app.html"), "utf8");
+  assert.match(html, /id="plot-set-count"[^>]*aria-live="polite"/);
+  assert.doesNotMatch(html, /id="project-figures"/);
+  assert.doesNotMatch(main, /mountProjectFigures|figure_library_(?:resolve_style|.*submission)/);
 });

--- a/tests/plotting-tips.test.ts
+++ b/tests/plotting-tips.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTestWindow } from "./helpers/dom.ts";
+import { mountPlottingTips, PLOTTING_EXAMPLE } from "../app/plotting-tips.ts";
+
+test("tips restore collapse preference, reopen and copy without submitting a request", async () => {
+  const window = createTestWindow(); const doc = window.document as unknown as Document;
+  const values = new Map([["sfl.plotting-tips.collapsed", "true"]]);
+  let copied = "";
+  const tips = mountPlottingTips(doc, doc.body, {
+    storage: { getItem: (k) => values.get(k) ?? null, setItem: (k, v) => { values.set(k, v); } },
+    copy: async (text) => { copied = text; },
+  });
+  assert.equal(tips.open, false);
+  tips.open = true; tips.dispatchEvent(new window.Event("toggle"));
+  assert.equal(values.get("sfl.plotting-tips.collapsed"), "false");
+  tips.querySelector("button")!.click(); await new Promise((r) => setTimeout(r, 0));
+  assert.equal(copied, PLOTTING_EXAMPLE);
+  assert.match(tips.querySelector('[role="status"]')!.textContent!, /已复制/);
+});
+
+test("tips work when storage and clipboard are unavailable", async () => {
+  const doc = createTestWindow().document as unknown as Document;
+  const tips = mountPlottingTips(doc, doc.body, {
+    storage: { getItem() { throw Error(); }, setItem() { throw Error(); } },
+    copy: async () => { throw Error(); },
+  });
+  tips.querySelector("button")!.click(); await new Promise((r) => setTimeout(r, 0));
+  assert.match(tips.querySelector('[role="status"]')!.textContent!, /手动复制/);
+  assert.equal(tips.querySelector("button")!.disabled, false);
+});
+
+
+test("tips are optional expression guidance, not project registration or persistent styles", () => {
+  const doc = createTestWindow().document as unknown as Document;
+  let copies = 0;
+  const tips = mountPlottingTips(doc, doc.body, { copy: async () => { copies++; } });
+  assert.equal(copies, 0);
+  assert.equal(tips.querySelectorAll("input, select, textarea, form").length, 0);
+  assert.match(tips.textContent!, /没有特殊要求可沿用模板/);
+  assert.doesNotMatch(tips.textContent!, /跨会话|记住我的|长期规范|归档|投稿包|Figure 1|项目图/);
+  tips.open = false;
+  assert.equal(tips.open, false);
+  tips.open = true;
+  assert.equal(tips.open, true);
+});


### PR DESCRIPTION
## 为什么拆分

按维护者确认的范围，从 #24 选择性接纳模板浏览、选择和当次需求提示；不把课题项目图管理作为开始绘图的前置条件。基于 #25 已合并后的 main，保留原提交者 @Yu-Qiao-sjtu 的贡献署名；不修改原始贡献分支。

## 本次保留

- 点击标题或卡片非交互区域切换选择，展示醒目的已选标记、复选框和滚动可见的计数栏。
- 缩略图与独立详情入口仍用于浏览，不会同时改变选择。
- 基础浏览不再发送缩略图点击、详情开关及初始能力记录的诊断工具调用；精确预览和确认交接的诊断仍保留。
- 可折叠的科研绘图提示和复制示例，只帮助表达本次数据、分组、尺寸、字体、配色及输出要求；存储或剪贴板被宿主禁止时可降级。
- 同步协议、Skill 和双语手册的选择语义与提示状态，明确勾选不等于预览凭证或执行授权。

## 明确不纳入

- #17 长期样式保存及样式优先级变化。
- #19 / #21 项目图身份、论文编号、目录管理、修订归档、投稿 ZIP 与语言准备。
- 原 #24 的 12 个新 MCP 工具；标准服务仍为 53 个工具。
- 核心搜索、Provider、Library 生命周期、模板资源、依赖和原有代码整理规则的修改。

这些后续需求仍保留，不由本 PR 关闭。原 #24 的全量版本不应直接合并；本 PR 仅承接已经确认的精选范围。#26 的后续整合需要以合并后的 main 为基线，避免恢复已移除的浏览诊断调用。

## 验证

- 完整 TypeScript 检查、App 和服务端构建通过。
- 完整 Node 测试 306/306 通过，0 失败、0 跳过。
- MCP 冒烟通过：53 个标准工具，原检索、预览确认、材料化、回执和反循环结果协议保持正常。
- 聚焦 UI／提示／绑定／文档回归 38/38 通过。
- 5 份文档的 120 个链接检查通过；其中 33 个外部链接仅计数，未抓取。
- 离线 headless Edge 使用真实组件与 CSS、合成数据验证标题选择、计数、详情不误选、Escape、复制、折叠、深浅主题、桌面和 390px 窄屏；无页面异常或横向溢出。
- Git 差异检查通过；GitHub 提交树与本地已审查树一致。

首轮验证受 Windows CRLF 资源检出和本机既有目录缓存影响。最终验证使用 Git 原始资源字节、隔离的用户配置／缓存／临时目录，且仅在测试进程关闭目录自动刷新；没有修改资源锁、削弱断言、安装依赖或修改系统设置。

未在真实 Wisp 宿主安装验收，未运行 R/Python 绘图，不把离线浏览器验证表述为真实宿主端到端验收。

Closes #18
Closes #23

Refs #24